### PR TITLE
Fix issue related to replace node operation bug in A4C

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/KubernetesTopologyModifier.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/KubernetesTopologyModifier.java
@@ -89,21 +89,22 @@ public class KubernetesTopologyModifier extends TopologyModifierSupport {
             return;
         }
 
-        CSARDependency yorcKubernetesTypesDependency = new CSARDependency();
-        yorcKubernetesTypesDependency.setName(YORC_KUBERNETES_TYPES_ARCHIVE_NAME);
-        yorcKubernetesTypesDependency.setVersion(YORC_KUBERNETES_TYPES_ARCHIVE_VERSION);
-        yorcKubernetesTypesDependency.setHash(yorcKubernetesTypesCsar.getDefinitionHash());
-
-        topology.getDependencies().add(yorcKubernetesTypesDependency);
+        // not necessary since the replaceNode will ensure dependencies will be correct
+        //
+        // CSARDependency yorcKubernetesTypesDependency = new CSARDependency();
+        // yorcKubernetesTypesDependency.setName(YORC_KUBERNETES_TYPES_ARCHIVE_NAME);
+        // yorcKubernetesTypesDependency.setVersion(YORC_KUBERNETES_TYPES_ARCHIVE_VERSION);
+        // yorcKubernetesTypesDependency.setHash(yorcKubernetesTypesCsar.getDefinitionHash());
+        //
+        // topology.getDependencies().add(yorcKubernetesTypesDependency);
         log.info("~~~~~~~~~ Yorc Plugin : Yorc kubernetes types archive added as dependency to the topology");
 
         // Transform alien kubernetes resource types to yorc kubernetes resource types
         //
-        // Treat service resource types
-        transformKubernetesResourceTypes(topology,  csar, "service", YORC_KUBERNETES_TYPES_ARCHIVE_VERSION);
-
         // Treat deployment resource types
         transformKubernetesResourceTypes(topology,  csar, "deployment", YORC_KUBERNETES_TYPES_ARCHIVE_VERSION);
+        // Treat service resource types
+        transformKubernetesResourceTypes(topology,  csar, "service", YORC_KUBERNETES_TYPES_ARCHIVE_VERSION);
 
 
         log.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ");


### PR DESCRIPTION
We have a bug in A4C in the replaceNode operation. This bug is related to recently added relationship operations in workflow. The replaceNode operation must manage relationship differently now that relation operations are part of the workflow.
The solution just consist in inverting the 2 replaces (first, the nodes that are target of relation ships, then those that are source).
