### PR TITLE
Change in Yorc Rest API for /deployments

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
@@ -149,7 +149,10 @@ public class RestClient {
             JSONObject obj = res.getBody().getObject();
             JSONArray array = obj.getJSONArray("deployments");
             for (int i = 0 ; i < array.length() ; i++) {
-                String depl = array.getJSONObject(i).getString("href");
+                JSONArray linkArray = array.getJSONObject(i).getJSONArray("links");
+                // The links array contains a single element, which is a
+                // reference to the deployment
+                String depl = linkArray.getJSONObject(0).getString("href");
                 log.debug("Found a deployment in Yorc: " + depl);
                 ret.add(depl);
             }


### PR DESCRIPTION
# Pull Request description

## Description of the change

After a change in Yorc REST API returning the list of deployments to fix a performance issue, had to change the parsing of the output of a /deployments GET request.
Corresponding change in Yorc : https://github.com/ystia/yorc/pull/18

### What I did

Updated code to parse the new response format. Example of a response :
```json
{
  "deployments": [
    {
      "id": "app1-Environment",
      "status": "DEPLOYED",
      "links": [
        {
          "rel": "deployment",
          "href": "/deployments/app1-Environment",
          "type": "application/json"
        }
      ]
    }
  ]
}
```

### How to verify it

In Alien4Cloud, install Yorc plugin, configure Yorc and a location, deploy an application, kill Alien4Cloud and relaunch it. Check you can see again your application as deployed in Alien4Cloud.

