### PR TITLE
Removing nodes of type yorc.nodes.openstack.PublicNetwork as connecti…

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/FipTopologyModifier.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/FipTopologyModifier.java
@@ -121,11 +121,6 @@ public class FipTopologyModifier extends TopologyModifierSupport {
                         fipNodeTemplate.setProperties(properties);
                         fipNodeTemplate.setCapabilities(capabilities);
 
-                        // The public network Node Template will be removed
-                        // now that a Floating IP Node Template Node
-                        // provides the required connectivity
-                        nodesToRemove.add(networkNodeTemplate);
-
                         // Creating a new relationship between the Node template
                         // and the Floating IP node.
                         // Not attempting to re-use/modify the relationship
@@ -149,6 +144,13 @@ public class FipTopologyModifier extends TopologyModifierSupport {
                     }
                 });
             }
+
+            // Now that Floating IP nodes have been created to provide the
+            // required connectivity, removing this public network node
+            nodesToRemove.add(networkNodeTemplate);
+            context.log().info(
+                "Public network <{}> removed as connectivity requirements are addressed by Floating IP Node Templates",
+                networkNodeTemplate.getName());
         });
 
         // Removing Public Network nodes for which a new Floating IP Node 


### PR DESCRIPTION
…vity requirements are addressed by Floating IP Node Templates

# Pull Request description

## Description of the change

Fix for an issue deploying this topology:
  * a network
  * a compute  without to the network.

The deployment failed with this error: 
```
[PANIC]Looking for a type "yorc.nodes.openstack.PublicNetwork" that do not exists in deployment xxx
```

### What I did

The node type "yorc.nodes.openstack.PublicNetwork" is only declared in the plugin, not in the orchestrator, because the plugin is expected to remove public network node templates and create Floating IP node templates to address connectivity requirements.
This is done while looping on the network relathionships.
Here as the network node template has no relationship, nothign is done, and the network node template is kept in the deployment topology.

The fix consists in adding the network node template to the set of nodes to remove, outside of the loop on network relationships.  

### How to verify it

On a setup using Alien4Cloud 2.0.0, a Yorc plugin from this branch, and a Yorc server configured to use an OpenStack location,
create a new application from scratch, containing a public network and a compute not connected to this network.

Go on in the deployment wizard, and check the matching step shows a log informing about the removal of this public network in the topology:

```
Public network <PublicNetwork> removed as connectivity requirements are addressed by Floating IP Node Templates
```
Deploy the application
Check the deployment was successful


