### PR TITLE
Fix issue on socket timeout exception for logs/events polling in http…

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
@@ -138,6 +138,12 @@ public class RestClient {
                     .setSslcontext(sslContext)
                     .build();
             Unirest.setHttpClient(httpClient);
+        } else {
+            CloseableHttpClient httpClient = HttpClients
+                    .custom()
+                    .setDefaultRequestConfig(clientConfig)
+                    .build();
+            Unirest.setHttpClient(httpClient);
         }
 
         try {


### PR DESCRIPTION
## Description of the change
Set connection_timeout and socket_timeout for non TLS mode to avoid:

2018-06-06 16:49:02 ERROR EventListenerTask:153 - listenDeploymentEvent Failed
com.mashape.unirest.http.exceptions.UnirestException: java.net.SocketTimeoutException: Read timed out
