### PR TITLE
Bugfix/no short notation for implementation artifact with type

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -67,14 +67,13 @@ public class LogListenerTask extends AlienTask {
      * @param paasId
      */
     private void postLog(PaaSDeploymentLog pdlog, String paasId) {
+        if (orchestrator.getDeploymentId(paasId) == null) {
+            log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4cloud deploymentID.", paasId);
+            return;
+        }
         // The DeploymentId is overridden by A4C plugin here with UUID
         pdlog.setDeploymentId(orchestrator.getDeploymentId(paasId));
         pdlog.setDeploymentPaaSId(paasId);
-        if (pdlog.getDeploymentId() == null) {
-            log.error("Must provide an Id for this log: " + pdlog.toString());
-            Thread.dumpStack();
-            return;
-        }
         orchestrator.saveLog(pdlog);
     }
 

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -787,14 +787,13 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
      * @param paasId
      */
     protected void postEvent(AbstractMonitorEvent event, String paasId) {
+        if (a4cDeploymentIds.get(paasId) == null) {
+            log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4cloud deploymentID.", paasId);
+            return;
+        }
         event.setDate((new Date()).getTime());
         event.setDeploymentId(a4cDeploymentIds.get(paasId));
         event.setOrchestratorId(paasId);
-        if (event.getDeploymentId() == null) {
-            log.error("Must provide an Id for this Event: " + event.toString());
-            Thread.dumpStack();
-            return;
-        }
         synchronized (toBeDeliveredEvents) {
             toBeDeliveredEvents.add(event);
         }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/service/ToscaComponentUtils.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/service/ToscaComponentUtils.java
@@ -15,6 +15,7 @@ import org.alien4cloud.tosca.model.definitions.IValue;
 import org.alien4cloud.tosca.model.definitions.Operation;
 import org.alien4cloud.tosca.model.definitions.PropertyDefinition;
 import org.alien4cloud.tosca.model.definitions.PropertyValue;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -23,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
  * @author Loic Albertin
  */
 public class ToscaComponentUtils {
-
 
     public static String join(Object[] list, String separator) {
         final StringBuilder buffer = new StringBuilder();
@@ -100,5 +100,17 @@ public class ToscaComponentUtils {
     public static boolean canUseShortNotationForOperationImplementation(Operation operation) {
         return StringUtils.isEmpty(operation.getImplementationArtifact().getArtifactType()) &&
                 StringUtils.isEmpty(operation.getImplementationArtifact().getRepositoryName());
+    }
+
+    /**
+     * Check if short notation can be used for implementation artifact
+     * ie if no inputs, no repository and no type provided as these information doesn't appear in short notation
+     * @param operation
+     * @return boolean true if short notation can be used
+     */
+    public static boolean canUseShortNotationForImplementationArtifact(Operation operation) {
+        return MapUtils.isEmpty(operation.getInputParameters()) &&
+                StringUtils.isEmpty(operation.getImplementationArtifact().getRepositoryName()) &&
+                StringUtils.isEmpty(operation.getImplementationArtifact().getArtifactType());
     }
 }

--- a/alien4cloud-yorc-plugin/src/main/resources/org/ystia/yorc/alien4cloud/plugin/tosca/instantiable_tosca_type.vm
+++ b/alien4cloud-yorc-plugin/src/main/resources/org/ystia/yorc/alien4cloud/plugin/tosca/instantiable_tosca_type.vm
@@ -21,7 +21,7 @@ ${propertyUtils.indent($indent)}interfaces:
 ${propertyUtils.indent($indent)}  ${yorcUtils.shortInterfaceName($interfaceEntry.key)}:
 #foreach($operationEntry in ${interfaceEntry.value.operations.entrySet()})
 #if($utils.isOperationImplemented($operationEntry.value))
-#set($enableImplementationArtifactShortNotation = $utils.canUseShortNotationForImplementationArtifact($operationEntry.value))
+#set($enableImplementationArtifactShortNotation = $yorcUtils.canUseShortNotationForImplementationArtifact($operationEntry.value))
 #if($enableImplementationArtifactShortNotation)
 ${propertyUtils.indent($indent)}    ${operationEntry.key}: $operationEntry.value.implementationArtifact.artifactRef
 #else

--- a/alien4cloud-yorc-plugin/src/test/java/org/ystia/yorc/alien4cloud/plugin/service/ToscaExportersTest.java
+++ b/alien4cloud-yorc-plugin/src/test/java/org/ystia/yorc/alien4cloud/plugin/service/ToscaExportersTest.java
@@ -207,4 +207,40 @@ public class ToscaExportersTest extends AbstractPluginTest {
         Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().containsKey("Comp1"), true);
     }
 
+    @Test
+    public void TestTopologyExporterWithImplementationArtifactNotationToNotShorten() throws Exception {
+        Mockito.reset(repositorySearchService);
+        Csar csar = new Csar("tosca-normative-types", "1.0.0-ALIEN20");
+        csar.setImportSource(CSARSource.ALIEN.name());
+        csar.setYamlFilePath("tosca-normative-types.yaml");
+        Mockito.when(repositorySearchService.getArchive("tosca-normative-types", "1.0.0-ALIEN20")).thenReturn(csar);
+        csar = new Csar("yorc-types", "1.0.0");
+        csar.setImportSource(CSARSource.ORCHESTRATOR.name());
+        csar.setYamlFilePath("yorc-types.yaml");
+        Mockito.when(repositorySearchService.getArchive("yorc-types", "1.0.0")).thenReturn(csar);
+        csar = new Csar("yorc-slurm-types", "1.0.0");
+        csar.setImportSource(CSARSource.ORCHESTRATOR.name());
+        csar.setYamlFilePath("yorc-slurm-types.yaml");
+        Mockito.when(repositorySearchService.getArchive("yorc-slurm-types", "1.0.0")).thenReturn(csar);
+
+        String rootDir = "src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca";
+        ParsingResult<ArchiveRoot>
+                parsingResult = parser.parseFile(Paths.get(rootDir, "tosca_topology_with_implementation_artifact.yaml"));
+        System.out.println(parsingResult.getContext().getParsingErrors());
+        assertNoBlocker(parsingResult);
+
+        Assert.assertNotNull(parsingResult.getResult().getTopology().getNodeTemplates());
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().size(), 1);
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().containsKey("Comp1"), true);
+
+        Assert.assertNotNull(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces());
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().size(), 1);
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().containsKey("tosca.interfaces.node.lifecycle.Runnable"), true);
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().get("tosca.interfaces.node.lifecycle.Runnable").getOperations().size(), 1);
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().get("tosca.interfaces.node.lifecycle.Runnable").getOperations().containsKey("run"), true);
+
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().get("tosca.interfaces.node.lifecycle.Runnable").getOperations().get("run").getImplementationArtifact().getArtifactType(), "yorc.artifacts.Deployment.SlurmJobBin");
+        Assert.assertEquals(parsingResult.getResult().getTopology().getNodeTemplates().get("Comp1").getInterfaces().get("tosca.interfaces.node.lifecycle.Runnable").getOperations().get("run").getImplementationArtifact().getArtifactRef(), "bin/submit.sh");
+    }
+
 }

--- a/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_topology_with_implementation_artifact.yaml
+++ b/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_topology_with_implementation_artifact.yaml
@@ -17,31 +17,26 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 
 metadata:
-  template_name: org.ystia.yorc.samples.job.sbatch.Component
+  template_name: TestTemplate
   template_version: 1.0.0-SNAPSHOT
   template_author: yorc
+
+description: "Test template"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.0.0
   - yorc-slurm-types:1.0.0
 
-node_types:
-  org.ystia.yorc.samples.job.sbatch.Component:
-    derived_from: yorc.nodes.slurm.Job
-    description: >
-      Sample component to show how to run a job
-    tags:
-      icon: /images/slurm.png
-    artifacts:
-      - bin:
-          type: tosca.artifacts.File
-          file: bin
-    interfaces:
-      tosca.interfaces.node.lifecycle.Runnable:
-        run:
-          inputs:
-            args: {get_property: [SELF, exec_args]}
-          implementation:
-            file: bin/submit.sh
-            type: yorc.artifacts.Deployment.SlurmJobBin
+topology_template:
+  node_templates:
+    Comp1:
+      type: yorc.nodes.slurm.Job
+      properties:
+        name: myTest
+      interfaces:
+        tosca.interfaces.node.lifecycle.Runnable:
+          run:
+            implementation:
+              file: bin/submit.sh
+              type: yorc.artifacts.Deployment.SlurmJobBin


### PR DESCRIPTION
# Pull Request description
When Tosca Topology is generated, no short notation must be used for implementation artifact when types is filled. Otherwise, the implementation type is lost orchestrator side.

## Description of the change
Override Alien method for Velocity Template

### How to verify it
By instance, deploy the [batch topology](https://github.com/ystia/yorc-a4c-plugin/tree/develop/tosca-samples/org/ystia/yorc/samples/job/sbatch) after having removed args and related inputs for run operation

### Description for the changelog

## Applicable Issues
