### PR TITLE
Treat unknown orchestrator deployments

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -60,10 +60,6 @@ public class EventListenerTask extends AlienTask {
                             log.debug("Received event has deploymentId : " + paasId);
                             String deploymentId = orchestrator.getDeploymentId(paasId);
                             if (deploymentId == null) {
-                                if (!orchestrator.isUnknownDeploymentId(paasId)) {
-                                    log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4Cloud deploymentID.", paasId);
-                                    orchestrator.setUnknownDeploymentId(paasId);
-                                }
                                 continue;
                             }
                             YorcRuntimeDeploymentInfo jrdi = orchestrator.getDeploymentInfo(paasId);
@@ -131,7 +127,7 @@ public class EventListenerTask extends AlienTask {
                                             }
                                             break;
                                         case "error":
-                                            log.warn("Error instance status in deploymentID:{} and nodeID:{}", paasId, eNode);
+                                            log.warn("Error instance status in deploymentID: {} and nodeID: {}", paasId, eNode);
                                             break;
                                         default:
                                             log.warn("Unknown instance status: " + eState);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -45,14 +45,10 @@ public class LogListenerTask extends AlienTask {
                     if (logResponse.getLogs() != null) {
                         for (LogEvent logEvent : logResponse.getLogs()) {
                             String paasId = logEvent.getDeploymentId();
+                            String deploymentId = orchestrator.getDeploymentId(paasId);
                             log.debug("Received log from Yorc: " + logEvent.toString());
                             log.debug("Received log has deploymentId : " + paasId);
-                            String deploymentId = orchestrator.getDeploymentId(paasId);
                             if (deploymentId == null) {
-                                if (!orchestrator.isUnknownDeploymentId(paasId)) {
-                                    log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4Cloud deploymentID.", paasId);
-                                    orchestrator.setUnknownDeploymentId(paasId);
-                                }
                                 continue;
                             }
                             // Post a PaaSDeploymentLog to a4c premium log

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -44,9 +44,22 @@ public class LogListenerTask extends AlienTask {
                     prevIndex = logResponse.getLast_index();
                     if (logResponse.getLogs() != null) {
                         for (LogEvent logEvent : logResponse.getLogs()) {
+                            String paasId = logEvent.getDeploymentId();
                             log.debug("Received log from Yorc: " + logEvent.toString());
-                            // add Premium Log
-                            postLog(toPaasDeploymentLog(logEvent), logEvent.getDeploymentId());
+                            log.debug("Received log has deploymentId : " + paasId);
+                            String deploymentId = orchestrator.getDeploymentId(paasId);
+                            if (deploymentId == null) {
+                                if (!orchestrator.isUnknownDeploymentId(paasId)) {
+                                    log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4Cloud deploymentID.", paasId);
+                                    orchestrator.setUnknownDeploymentId(paasId);
+                                }
+                                continue;
+                            }
+                            // Post a PaaSDeploymentLog to a4c premium log
+                            PaaSDeploymentLog paasDeploymentLog = toPaasDeploymentLog(logEvent);
+                            paasDeploymentLog.setDeploymentId(deploymentId);
+                            paasDeploymentLog.setDeploymentPaaSId(paasId);
+                            orchestrator.saveLog(paasDeploymentLog);
                         }
                     }
                 }
@@ -61,22 +74,6 @@ public class LogListenerTask extends AlienTask {
             }
         }
     }
-    /**
-     * Post a PaaSDeploymentLog to a4c premium log
-     * @param pdlog
-     * @param paasId
-     */
-    private void postLog(PaaSDeploymentLog pdlog, String paasId) {
-        if (orchestrator.getDeploymentId(paasId) == null) {
-            log.warn("The orchestrator deploymentID:{} doesn't match with any associated Alien4cloud deploymentID.", paasId);
-            return;
-        }
-        // The DeploymentId is overridden by A4C plugin here with UUID
-        pdlog.setDeploymentId(orchestrator.getDeploymentId(paasId));
-        pdlog.setDeploymentPaaSId(paasId);
-        orchestrator.saveLog(pdlog);
-    }
-
 
     private PaaSDeploymentLog toPaasDeploymentLog(final LogEvent pLogEvent) {
         PaaSDeploymentLog deploymentLog = new PaaSDeploymentLog();

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -51,6 +51,7 @@ import alien4cloud.paas.plan.ToscaNodeLifecycleConstants;
 import alien4cloud.tosca.parser.ToscaParser;
 import com.google.common.collect.Lists;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alien4cloud.tosca.catalog.index.IToscaTypeSearchService;
 import org.alien4cloud.tosca.catalog.repository.CsarFileRepository;
@@ -87,6 +88,23 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
     private final List<AbstractMonitorEvent> toBeDeliveredEvents = new ArrayList<>();
     private ProviderConfig providerConfiguration;
     private Map<String, String> a4cDeploymentIds = Maps.newHashMap();
+
+    /**
+     * Keep in mind the pass (yorc) deploymentIds that have no
+     * correspondent deploymentId in Alien. This can arrive for multiple reasons:
+     * - deployment was created with yorc's CLI
+     * - deployment was created with another Alien instance
+     * - Alien was restared after runtime removed
+     */
+    private List<String> unknownDeploymentIds = new ArrayList<>();
+
+    protected boolean isUnknownDeploymentId(String paasId) {
+        return unknownDeploymentIds.contains(paasId);
+    }
+
+    protected void setUnknownDeploymentId(String paasId) {
+        unknownDeploymentIds.add(paasId);
+    }
 
     @Inject
     private IToscaTypeSearchService toscaTypeSearchService;


### PR DESCRIPTION
# Pull Request description
Refactor treatement of logs and events requested from Yorc and received by Alien. Clean up log traces concerning deployments that are not known by Alien but known by the Yorc orchestrator.

## Description of the change
Introduce data structure to keep a list of unknown deployments

### What I did
Define unknownDeploymentIds in YorcPaasProvider and use it in LogListenerTask and EventListenerTask

### How I did it

### How to verify it
Need an application not known by Alien. You may create a deployment D with Alien, then stop Alien, remove runtime and restart-it. 
The deployment D is not known by Alien. You can check the Alien log traces in logs/alien4cloud.log

