### PR TITLE
Changed GCP compute instance parameter address to addresses

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -69,11 +69,11 @@ node_types:
           keys startup-script or startup-script-url can be used to specify a script
           that will be executed by the Compute Node once it starts running.
         required: false
-      address:
+      addresses:
         type: string
         description: >
-          Assigns the given external address to the instance.
-          If not specified, and no_address is not true, an ephemeral IP address will be assigned.
+          Comma-separated list of external addresses. One external address will be assigned to each scalable Compute Node instance.
+          If not specified or if there aren't enough addresses specified for the number of scalable instances to create, and no_address is not true, an ephemeral IP address will be assigned.
         required: false
       no_address:
         type: boolean


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Changed GCP compute instance parameter `address` to `addresses`, comma-separated list of items.

### How I did it

To manage a topology with a compute node having its scalable capability default and max value > 1, changed the GCP compute parameter `address` allowing to speficy an address already reserved to use as a public address by a GCP compute instance.
The parameter is now `addresses`, and is a comma-separated list of external addresses. One external address will be assigned to each scalable Compute Node instance.
If not specified or if there aren't enough addresses specified for the number of scalable instances to create, and `no_address` is not true, an ephemeral IP address will be assigned.

### How to verify it

To be used with Yorc pull request https://github.com/ystia/yorc/pull/46

Create a topology template containing a Compute node , update the Scalable capability to set default and max values to 2.
Choose to deploy this topology on a Google Cloud location, updating the Nodes Matching  Compute resource property "addresses" to specify 2 IP addresses separated by a comma
Deploy the topology
Check Yorc attempts to create 2 GCP compute instances, the first one using the first address specified and the second one using the second address specified.

