### PR TITLE
Bug fix: recursively manage folder artifacts (ALIEN-2956)

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
@@ -411,8 +411,7 @@ public class DeployTask extends AlienTask {
                 Path artifactPath = Paths.get(from);
                 try {
                     String filename = artifact.getArtifactRef();
-                    createZipEntries(filename, zout);
-                    copy(artifactPath.toFile(), zout);
+                    recursivelyCopyArtifact(artifactPath, filename, zout);
                 } catch (Exception e) {
                     log.error("Could not copy local artifact " + aname, e);
                 }
@@ -423,8 +422,7 @@ public class DeployTask extends AlienTask {
                 Path artifactPath = Paths.get(from);
                 try {
                     String filename = artifact.getArtifactRef();
-                    createZipEntries(filename, zout);
-                    copy(artifactPath.toFile(), zout);
+                    recursivelyCopyArtifact(artifactPath, filename, zout);
                 } catch (Exception e) {
                     log.error("Could not copy remote artifact " + aname, e);
                 }
@@ -432,6 +430,20 @@ public class DeployTask extends AlienTask {
                 // TODO Remove this when a4c bug SUPALIEN-926 is fixed.
                 addRemoteArtifactInTopology(name, da.getKey(), artifact);
             }
+        }
+    }
+
+    private void recursivelyCopyArtifact(Path path, String baseTargetName, ZipOutputStream zout) throws IOException {
+        if (path.toFile().isDirectory()) {
+            String folderName = baseTargetName + "/";
+            createZipEntries(folderName, zout);
+            for (String file : path.toFile().list()) {
+                Path filePath = path.resolve(file);
+                recursivelyCopyArtifact(filePath, folderName + file, zout);
+            }
+        } else {
+            createZipEntries(baseTargetName, zout);
+            copy(path.toFile(), zout);
         }
     }
 
@@ -582,7 +594,7 @@ public class DeployTask extends AlienTask {
                             } else {
                                 yaml = orchestrator.getToscaComponentExporter().getYaml(root);
                             }
-                            
+
                             zout.write(yaml.getBytes(Charset.forName("UTF-8")));
                         } else {
                             copy(file, zout);


### PR DESCRIPTION
# Pull Request description

## Description of the change
Fix a bug when an artifact is a folder : it wasn't copied well in the topology.zip

### What I did
Deep copy artifact that are folders

### How I did it
Add a recursive method to deeply copy artifact when it is/contains folders.

### How to verify it
Use a folder in a topolgy and use a mock component that ls this folder.

### Description for the changelog

## Applicable Issues
