### PR TITLE
Bugfix/error on restart orchestrator

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -243,6 +243,7 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
         }
         // prov
         log.info(fileRepository.getRootPath().toString());
+        startLogsAndEvents();
     }
 
     /**

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -149,9 +149,9 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
     }
 
     public void stopLogsAndEvents() {
-        eventListenerTask.stop();
-        logListenerTask.stop();
-        taskManager.stop();
+        if (eventListenerTask != null) eventListenerTask.stop();
+        if (logListenerTask != null) logListenerTask.stop();
+        if (taskManager != null) taskManager.stop();
     }
 
     public void startLogsAndEvents() {

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
@@ -47,9 +47,7 @@ public class YstiaOrchestratorFactory implements IOrchestratorPluginFactory<Yorc
 
     @Override
     public YorcPaaSProvider newInstance() {
-        YorcPaaSProvider instance = beanFactory.getBean(YorcPaaSProvider.class);
-        instance.startLogsAndEvents();
-        return instance;
+        return beanFactory.getBean(YorcPaaSProvider.class);
     }
 
     @Override


### PR DESCRIPTION
Fix error when we disable-enable the orchestrator we get an error in the logs of a4C:

```
2018-08-24 09:59:56 INFO  YorcPaaSProvider:159 - Starting Yorc events & logs listeners
2018-08-24 09:59:56 ERROR EventListenerTask:167 - listenDeploymentEvent Failed
java.lang.NullPointerException: null
	at org.ystia.yorc.alien4cloud.plugin.rest.RestClient.getEventFromYorc(RestClient.java:343) ~[305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.EventListenerTask.run(EventListenerTask.java:60) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.TaskManager.nextWork(TaskManager.java:89) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.TaskManager$WorkThread.run(TaskManager.java:141) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
2018-08-24 09:59:56 WARN  LogListenerTask:72 - listen Yorc Logs Failed
java.lang.NullPointerException: null
	at org.ystia.yorc.alien4cloud.plugin.rest.RestClient.getLogFromYorc(RestClient.java:333) ~[305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.LogListenerTask.run(LogListenerTask.java:50) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.TaskManager.nextWork(TaskManager.java:89) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
	at org.ystia.yorc.alien4cloud.plugin.TaskManager$WorkThread.run(TaskManager.java:141) [305711ce-542f-4e21-9140-567d6fcd554d/:?]
```

This cause no trouble, but an error stack trace in A4C logs

# Applicable Issues

#46 