### PR TITLE
Upgraded paramiko and cryptography dependencies

### DIFF
--- a/tosca-samples/org/ystia/yorc/samples/vision/linux/ansible/playbooks/roles/cchurch.virtualenv/requirements.txt
+++ b/tosca-samples/org/ystia/yorc/samples/vision/linux/ansible/playbooks/roles/cchurch.virtualenv/requirements.txt
@@ -12,7 +12,7 @@ bumpversion==0.5.3
 certifi==2018.1.18        # via requests
 cffi==1.11.4              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-cryptography==2.1.4       # via ansible, paramiko
+cryptography==2.3         # via ansible, paramiko
 docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
 enum34==1.1.6             # via cryptography
@@ -20,7 +20,7 @@ idna==2.6                 # via cryptography, requests
 ipaddress==1.0.19         # via cryptography, docker-py
 jinja2==2.10              # via ansible
 markupsafe==1.0           # via jinja2
-paramiko==2.4.0           # via ansible
+paramiko==2.4.1           # via ansible
 pluggy==0.6.0             # via tox
 py==1.5.2                 # via tox
 pyasn1==0.4.2             # via paramiko


### PR DESCRIPTION
# Pull Request description

## Description of the change

Upgraded two components whose version was known to have potential vulnerabilities.

### What I did

Upgraded cryptography to 2.3 and paramiko to 2.1

### How to verify it

Deploy the Vision sample application on GCP and check it still works fine with upgraded dependencies
