### PR TITLE
Feature/gcloud static ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Upgrade to Alien4Cloud 2.1 ([GH-50](https://github.com/ystia/yorc-a4c-plugin/issues/50))
 
+### FEATURES
+
+* Support GCE Public IPs. ([GH-82](https://github.com/ystia/yorc/issues/82))
+
 ### IMPROVEMENTS
 
 * Make the run step of a Job execution asynchronous not to block a worker during the duration of the job. ([GH-85](https://github.com/ystia/yorc/issues/85))

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
@@ -74,7 +74,10 @@ public class YstiaOrchestratorFactory implements IOrchestratorPluginFactory<Yorc
     public ArtifactSupport getArtifactSupport() {
         // support all type of implementations artifacts
         return new ArtifactSupport(new String[]{"tosca.artifacts.Implementation.Python",
-                "tosca.artifacts.Implementation.Bash", "tosca.artifacts.Implementation.Ansible", "org.alien4cloud.artifacts.AnsiblePlaybook", "tosca.artifacts.Deployment.Image.Container.Docker", "tosca.artifacts.Deployment.Image.Container.Docker.Kubernetes", "yorc.artifacts.Deployment.SlurmJob"});
+                "tosca.artifacts.Implementation.Bash", "tosca.artifacts.Implementation.Ansible", "org.alien4cloud.artifacts.AnsiblePlaybook",
+                "tosca.artifacts.Deployment.Image.Container.Docker", "tosca.artifacts.Deployment.Image.Container.Docker.Kubernetes",
+                "yorc.artifacts.Deployment.SlurmJob",
+                "yorc.artifacts.google.Deployment.Address"});
     }
 
     @Override

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
@@ -77,7 +77,7 @@ public class YstiaOrchestratorFactory implements IOrchestratorPluginFactory<Yorc
                 "tosca.artifacts.Implementation.Bash", "tosca.artifacts.Implementation.Ansible", "org.alien4cloud.artifacts.AnsiblePlaybook",
                 "tosca.artifacts.Deployment.Image.Container.Docker", "tosca.artifacts.Deployment.Image.Container.Docker.Kubernetes",
                 "yorc.artifacts.Deployment.SlurmJob",
-                "yorc.artifacts.google.Deployment.Address"});
+                "yorc.artifacts.google.Deployment"});
     }
 
     @Override

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/GoogleAddressTopologyModifier.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/GoogleAddressTopologyModifier.java
@@ -81,7 +81,7 @@ public class GoogleAddressTopologyModifier extends TopologyModifierSupport {
 
                         // Creating a new Address Node Template that will be
                         // associated to this Node Template requiring an assignment
-                        String name = "address_" + nodeTemplate.getName();
+                        String name = nodeTemplate.getName() + "_address";
                         NodeTemplate addressNodeTemplate = addNodeTemplate(
                                 csar,
                                 topology,

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/GoogleStaticIPTopologyModifier.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/GoogleStaticIPTopologyModifier.java
@@ -1,0 +1,138 @@
+package org.ystia.yorc.alien4cloud.plugin.modifiers;
+
+import alien4cloud.paas.wf.validation.WorkflowValidator;
+import alien4cloud.tosca.context.ToscaContextual;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.alien4cloud.alm.deployment.configuration.flow.FlowExecutionContext;
+import org.alien4cloud.alm.deployment.configuration.flow.TopologyModifierSupport;
+import org.alien4cloud.tosca.catalog.index.IToscaTypeSearchService;
+import org.alien4cloud.tosca.model.Csar;
+import org.alien4cloud.tosca.model.definitions.AbstractPropertyValue;
+import org.alien4cloud.tosca.model.templates.Capability;
+import org.alien4cloud.tosca.model.templates.NodeTemplate;
+import org.alien4cloud.tosca.model.templates.Topology;
+import org.alien4cloud.tosca.model.types.NodeType;
+import org.alien4cloud.tosca.normative.constants.NormativeRelationshipConstants;
+import org.alien4cloud.tosca.utils.TopologyNavigationUtil;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.*;
+
+@Slf4j
+@Component(value = GoogleStaticIPTopologyModifier.YORC_GOOGLE_STATIC_IP_MODIFIER_TAG)
+public class GoogleStaticIPTopologyModifier extends TopologyModifierSupport {
+    public static final String YORC_GOOGLE_STATIC_IP_MODIFIER_TAG = "yorc-google-static-ip-modifier";
+
+    @Inject
+    private IToscaTypeSearchService toscaTypeSearchService;
+
+    @Override
+    @ToscaContextual
+    public void process(Topology topology, FlowExecutionContext context) {
+        log.debug("Processing topology " + topology.getId());
+
+        try {
+            WorkflowValidator.disableValidationThreadLocal.set(true);
+            doProcess(topology, context);
+        } finally {
+            WorkflowValidator.disableValidationThreadLocal.remove();
+        }
+    }
+
+    private void doProcess(Topology topology, FlowExecutionContext context) {
+        Csar csar = new Csar(topology.getArchiveName(), topology.getArchiveVersion());
+
+        Set<NodeTemplate> publicNetworksNodes = TopologyNavigationUtil.getNodesOfType(topology, "yorc.nodes.google.PublicNetwork", false);
+        String assignableCap = "yorc.capabilities.google.Assignable";
+
+        String staticIPTypeName = "yorc.nodes.google.StaticIP";
+        NodeType staticIPNodeType = toscaTypeSearchService.findMostRecent(NodeType.class, staticIPTypeName);
+        Set<NodeTemplate> nodesToRemove = new HashSet<NodeTemplate>();
+        List<AssignmentRelationship> relationshipsToAdd = new ArrayList<>();
+
+        publicNetworksNodes.forEach(networkNodeTemplate -> {
+            // For each Node Template requiring a connection to this Public
+            // Network, creating a new static IP Node Template
+            for (NodeTemplate nodeTemplate : new ArrayList<>(topology.getNodeTemplates().values())) {
+                final AbstractPropertyValue ip = networkNodeTemplate.getProperties().get("ip");
+
+                if (nodeTemplate.getRelationships() == null) continue;
+
+                nodeTemplate.getRelationships().forEach((rel, relationshipTemplate) -> {
+                    if (relationshipTemplate.getTarget().equals(networkNodeTemplate.getName())) {
+                        Map<String, AbstractPropertyValue> properties = new LinkedHashMap<>();
+                        properties.put("ip", ip);
+
+
+
+                        Map<String, Capability> capabilities = new LinkedHashMap<>();
+                        Capability assignmentCap = new Capability();
+                        assignmentCap.setType(assignableCap);
+                        capabilities.put("assignment", assignmentCap);
+
+                        if (staticIPNodeType == null) {
+                            context.log().error("Node type with name <{}> cannot be found in the catalog.",
+                                    staticIPTypeName);
+                            return;
+                        }
+
+                        // Creating a new static IP Node Template that will be
+                        // associated to this Node Template requiring an assignment
+                        String name = "StaticIP" + nodeTemplate.getName();
+                        NodeTemplate staticIPNodeTemplate = addNodeTemplate(
+                                csar,
+                                topology,
+                                name,
+                                staticIPNodeType.getElementId(),
+                                staticIPNodeType.getArchiveVersion());
+
+                        staticIPNodeTemplate.setProperties(properties);
+                        staticIPNodeTemplate.setCapabilities(capabilities);
+
+                        // Creating a new relationship between the Node template
+                        // and the static IP node.
+                        relationshipsToAdd.add(new AssignmentRelationship(
+                                nodeTemplate, // source
+                                staticIPNodeTemplate.getName(), // target
+                                relationshipTemplate.getRequirementName(), // A compute requirement for assignation is expected
+                                "assignment"));
+
+                        context.log().info(
+                                "<{}> created to provide a static IP address to <{}> on network <{}>",
+                                name,
+                                nodeTemplate.getName(),
+                                networkNodeTemplate.getName());
+                    }
+                });
+            }
+
+            // Remove the public network node as replaced by StaticIP node
+            nodesToRemove.add(networkNodeTemplate);
+            context.log().info(
+                    "Public network <{}> removed as connectivity requirements are addressed by static IP Node Templates",
+                    networkNodeTemplate.getName());
+
+            // Creating a relationship between each new staticIP Node Template
+            // and the Source Node Template having an assignment requirement
+            relationshipsToAdd.forEach( rel -> addRelationshipTemplate(
+                    csar,
+                    topology,
+                    rel.sourceNode,
+                    rel.targetNodeName,
+                    NormativeRelationshipConstants.ROOT,
+                    rel.requirementName,
+                    rel.targetCapabilityName));
+        });
+
+    }
+
+    @AllArgsConstructor
+    private class AssignmentRelationship {
+        private NodeTemplate sourceNode;
+        private String targetNodeName;
+        private String requirementName;
+        private String targetCapabilityName;
+    }
+}

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/LocationCreationListener.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/LocationCreationListener.java
@@ -57,6 +57,7 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
     private LocationModifierReference serviceTopologyModifierRef;
     private LocationModifierReference kubernetesTopologyModifierRef;
     private LocationModifierReference yorcKubernetesTopologyModifierRef;
+    private LocationModifierReference googleStaticIPModifierRef;
 
     @PostConstruct
     public synchronized void init() {
@@ -88,6 +89,11 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
         kubernetesTopologyModifierRef.setPluginId("alien4cloud-kubernetes-plugin");
         kubernetesTopologyModifierRef.setBeanName("kubernetes-modifier");
         kubernetesTopologyModifierRef.setPhase(FlowPhases.POST_LOCATION_MATCH);
+
+        googleStaticIPModifierRef = new LocationModifierReference();
+        googleStaticIPModifierRef.setPluginId(selfContext.getPlugin().getId());
+        googleStaticIPModifierRef.setBeanName(GoogleStaticIPTopologyModifier.YORC_GOOGLE_STATIC_IP_MODIFIER_TAG);
+        googleStaticIPModifierRef.setPhase(FlowPhases.POST_NODE_MATCH);
     }
 
 
@@ -104,6 +110,8 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
             } else if (YstiaOrchestratorFactory.KUBERNETES.equals(event.getLocation().getInfrastructureType())) {
                 locationModifierService.add(event.getLocation(), yorcKubernetesTopologyModifierRef);
                 locationModifierService.add(event.getLocation(), kubernetesTopologyModifierRef);
+            } else if (YstiaOrchestratorFactory.GOOGLE.equals(event.getLocation().getInfrastructureType())) {
+                locationModifierService.add(event.getLocation(), googleStaticIPModifierRef);
             }
             locationModifierService.add(event.getLocation(), wfOperationHostModifierRef);
             locationModifierService.add(event.getLocation(), serviceTopologyModifierRef);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/LocationCreationListener.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/modifiers/LocationCreationListener.java
@@ -57,7 +57,7 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
     private LocationModifierReference serviceTopologyModifierRef;
     private LocationModifierReference kubernetesTopologyModifierRef;
     private LocationModifierReference yorcKubernetesTopologyModifierRef;
-    private LocationModifierReference googleStaticIPModifierRef;
+    private LocationModifierReference googleAddressModifierRef;
 
     @PostConstruct
     public synchronized void init() {
@@ -90,10 +90,10 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
         kubernetesTopologyModifierRef.setBeanName("kubernetes-modifier");
         kubernetesTopologyModifierRef.setPhase(FlowPhases.POST_LOCATION_MATCH);
 
-        googleStaticIPModifierRef = new LocationModifierReference();
-        googleStaticIPModifierRef.setPluginId(selfContext.getPlugin().getId());
-        googleStaticIPModifierRef.setBeanName(GoogleStaticIPTopologyModifier.YORC_GOOGLE_STATIC_IP_MODIFIER_TAG);
-        googleStaticIPModifierRef.setPhase(FlowPhases.POST_NODE_MATCH);
+        googleAddressModifierRef = new LocationModifierReference();
+        googleAddressModifierRef.setPluginId(selfContext.getPlugin().getId());
+        googleAddressModifierRef.setBeanName(GoogleAddressTopologyModifier.YORC_GOOGLE_ADDRESS_MODIFIER_TAG);
+        googleAddressModifierRef.setPhase(FlowPhases.POST_NODE_MATCH);
     }
 
 
@@ -111,7 +111,7 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
                 locationModifierService.add(event.getLocation(), yorcKubernetesTopologyModifierRef);
                 locationModifierService.add(event.getLocation(), kubernetesTopologyModifierRef);
             } else if (YstiaOrchestratorFactory.GOOGLE.equals(event.getLocation().getInfrastructureType())) {
-                locationModifierService.add(event.getLocation(), googleStaticIPModifierRef);
+                locationModifierService.add(event.getLocation(), googleAddressModifierRef);
             }
             locationModifierService.add(event.getLocation(), wfOperationHostModifierRef);
             locationModifierService.add(event.getLocation(), serviceTopologyModifierRef);

--- a/alien4cloud-yorc-plugin/src/main/resources/commons/resources/yorc-types.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/commons/resources/yorc-types.yaml
@@ -58,6 +58,15 @@ capability_types:
     #     description: Credentials used to provision the resource
     #     required: false
 
+  yorc.capabilities.Assignable:
+    derived_from: tosca.capabilities.Root
+
+relationship_types:
+  yorc.relationships.AssignsTo:
+    derived_from: tosca.relationships.Root
+    description: This type represents an IP address assignment to a Compute node type.
+    valid_target_types: [ yorc.capabilities.Assignable ]
+
 node_types:
   yorc.nodes.Compute:
     derived_from: tosca.nodes.Compute

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/fake.sh
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/fake.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -8,10 +8,6 @@ imports:
   - tosca-normative-types:${tosca.normative.types.version}
   - yorc-types:${yorc.types.version}
 
-capability_types:
-  yorc.capabilities.google.Assignable:
-    derived_from: tosca.capabilities.Root
-
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -103,11 +99,18 @@ node_types:
           Comma-separated list of tags to apply to the instances for identifying
           the instances to which network firewall rules will apply.
         required: false
+    requirements:
+      - assignment:
+          capability: yorc.capabilities.Assignable
+          node: yorc.nodes.google.StaticIP
+          relationship: yorc.relationships.AssignsTo
+          occurrences: [0, UNBOUNDED]
+
   yorc.nodes.google.Network:
     derived_from: tosca.nodes.Network
 
   yorc.nodes.google.StaticIP:
-    derived_from: tosca.nodes.Root
+    derived_from: tosca.nodes.Network
     properties:
     # See https://www.terraform.io/docs/providers/google/r/compute_address.html
       name:
@@ -117,7 +120,7 @@ node_types:
           Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
           which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
         required: true
-      address:
+      addresses:
         type: string
         description: >
           Comma-separated list of static external addresses. Only IPv4 is supported.
@@ -130,14 +133,14 @@ node_types:
         required: false
     capabilities:
       assignment:
-        type: yorc.capabilities.google.Assignable
+        type: yorc.capabilities.Assignable
 
   yorc.nodes.google.PublicNetwork:
     derived_from: tosca.nodes.Network
     properties:
-      ip:
+      addresses:
         type: string
-        description: A specific Static IP to use. If not specified, a new one will be assigned.
+        description: A comma-separated static IPs to use.
         required: false
 
   ##############################################

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -8,6 +8,10 @@ imports:
   - tosca-normative-types:${tosca.normative.types.version}
   - yorc-types:${yorc.types.version}
 
+artifact_types:
+  yorc.artifacts.google.Deployment.Address:
+    derived_from: tosca.artifacts.Deployment
+
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -110,7 +114,7 @@ node_types:
     derived_from: tosca.nodes.Network
 
   yorc.nodes.google.StaticIP:
-    derived_from: tosca.nodes.Network
+    derived_from: tosca.nodes.Root
     properties:
     # See https://www.terraform.io/docs/providers/google/r/compute_address.html
       name:
@@ -134,6 +138,16 @@ node_types:
     capabilities:
       assignment:
         type: yorc.capabilities.Assignable
+    interfaces:
+      Standard:
+        create:
+          implementation:
+            file: fake.sh
+            type: yorc.artifacts.google.Deployment.Address
+        delete:
+          implementation:
+            file: fake.sh
+            type: yorc.artifacts.google.Deployment.Address
 
   yorc.nodes.google.PublicNetwork:
     derived_from: tosca.nodes.Network

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -106,34 +106,61 @@ node_types:
     requirements:
       - assignment:
           capability: yorc.capabilities.Assignable
-          node: yorc.nodes.google.StaticIP
+          node: yorc.nodes.google.Address
           relationship: yorc.relationships.AssignsTo
           occurrences: [0, UNBOUNDED]
 
   yorc.nodes.google.Network:
     derived_from: tosca.nodes.Network
 
-  yorc.nodes.google.StaticIP:
+  yorc.nodes.google.Address:
     derived_from: tosca.nodes.Root
     properties:
     # See https://www.terraform.io/docs/providers/google/r/compute_address.html
-      name:
-        type: string
-        description: >
-          Name of the resource. The name must be 1-63 characters long, and comply with RFC1035.
-          Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
-          which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
-        required: true
       addresses:
         type: string
         description: >
-          Comma-separated list of static external addresses. Only IPv4 is supported.
+          Comma-separated list of external addresses. Only IPv4 is supported.
           The IP address must be inside the specified subnetwork, if any.
+        required: false
+      address_type:
+        type: string
+        description: >
+          The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
+        required: false
+      description:
+        type: string
+        description: >
+          An optional description of this resource.
+        required: false
+      network_tier:
+        type: string
+        description: >
+          The networking tier used for configuring this address. This field can take the following values: PREMIUM or STANDARD.
+          If this field is not specified, it is assumed to be PREMIUM.
+        required: false
+      subnetwork:
+        type: string
+        description: >
+          The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range.
+          This field can only be used with INTERNAL type with GCE_ENDPOINT/DNS_RESOLVER purposes.
         required: false
       labels:
         type: string
         description: >
-          Comma-separated list of label KEY=VALUE pairs to assign to the address.
+          Comma-separated list of label KEY=VALUE pairs to assign to the Compute Address.
+        required: false
+        entry_schema:
+          type: string
+      region:
+        type: string
+        description: >
+          The Region in which the created address should reside. If it is not provided, the infrastructure location region is used.
+        required: false
+      project:
+        type: string
+        description: >
+          The ID of the project in which the resource belongs. If it is not provided, the infrastructure location project is used.
         required: false
     capabilities:
       assignment:
@@ -148,14 +175,23 @@ node_types:
           implementation:
             file: fake.sh
             type: yorc.artifacts.google.Deployment.Address
+    attributes:
+      ip_address:
+        type: string
+        description: The compute IP address.
 
   yorc.nodes.google.PublicNetwork:
     derived_from: tosca.nodes.Network
     properties:
       addresses:
         type: string
-        description: A comma-separated static IPs to use.
+        description: A comma-separated address IPs to use.
         required: false
+      region:
+        type: string
+        description: >
+          The public network Google Compute Platform region
+        required: true
 
   ##############################################
   # Abstract resources used for auto-config

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -8,6 +8,10 @@ imports:
   - tosca-normative-types:${tosca.normative.types.version}
   - yorc-types:${yorc.types.version}
 
+capability_types:
+  yorc.capabilities.google.Assignable:
+    derived_from: tosca.capabilities.Root
+
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -69,12 +73,6 @@ node_types:
           keys startup-script or startup-script-url can be used to specify a script
           that will be executed by the Compute Node once it starts running.
         required: false
-      addresses:
-        type: string
-        description: >
-          Comma-separated list of external addresses. One external address will be assigned to each scalable Compute Node instance.
-          If not specified or if there aren't enough addresses specified for the number of scalable instances to create, and no_address is not true, an ephemeral IP address will be assigned.
-        required: false
       no_address:
         type: boolean
         description: >
@@ -105,8 +103,42 @@ node_types:
           Comma-separated list of tags to apply to the instances for identifying
           the instances to which network firewall rules will apply.
         required: false
+  yorc.nodes.google.Network:
+    derived_from: tosca.nodes.Network
+
+  yorc.nodes.google.StaticIP:
+    derived_from: tosca.nodes.Root
+    properties:
+    # See https://www.terraform.io/docs/providers/google/r/compute_address.html
+      name:
+        type: string
+        description: >
+          Name of the resource. The name must be 1-63 characters long, and comply with RFC1035.
+          Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
+          which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
+        required: true
+      address:
+        type: string
+        description: >
+          Comma-separated list of static external addresses. Only IPv4 is supported.
+          The IP address must be inside the specified subnetwork, if any.
+        required: false
+      labels:
+        type: string
+        description: >
+          Comma-separated list of label KEY=VALUE pairs to assign to the address.
+        required: false
+    capabilities:
+      assignment:
+        type: yorc.capabilities.google.Assignable
+
   yorc.nodes.google.PublicNetwork:
     derived_from: tosca.nodes.Network
+    properties:
+      ip:
+        type: string
+        description: A specific Static IP to use. If not specified, a new one will be assigned.
+        required: false
 
   ##############################################
   # Abstract resources used for auto-config

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -190,8 +190,14 @@ node_types:
       region:
         type: string
         description: >
-          The public network Google Compute Platform region
-        required: true
+          The public network Google Compute Platform region. If it is not provided, the infrastructure location region is used.
+        required: false
+      subnetwork:
+        type: string
+        description: >
+          The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range.
+          This field can only be used with INTERNAL type with GCE_ENDPOINT/DNS_RESOLVER purposes.
+        required: false
 
   ##############################################
   # Abstract resources used for auto-config

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -9,7 +9,7 @@ imports:
   - yorc-types:${yorc.types.version}
 
 artifact_types:
-  yorc.artifacts.google.Deployment.Address:
+  yorc.artifacts.google.Deployment:
     derived_from: tosca.artifacts.Deployment
 
 node_types:
@@ -170,11 +170,11 @@ node_types:
         create:
           implementation:
             file: fake.sh
-            type: yorc.artifacts.google.Deployment.Address
+            type: yorc.artifacts.google.Deployment
         delete:
           implementation:
             file: fake.sh
-            type: yorc.artifacts.google.Deployment.Address
+            type: yorc.artifacts.google.Deployment
     attributes:
       ip_address:
         type: string

--- a/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/google/resources/resources.yaml
@@ -105,6 +105,8 @@ node_types:
           Comma-separated list of tags to apply to the instances for identifying
           the instances to which network firewall rules will apply.
         required: false
+  yorc.nodes.google.PublicNetwork:
+    derived_from: tosca.nodes.Network
 
   ##############################################
   # Abstract resources used for auto-config


### PR DESCRIPTION
# Pull Request description
Allow to deploy a compute on GCE with an external static IP

See https://github.com/ystia/yorc/pull/173 for more information

## Description of the change

Add topology modifier to transform relationship between a **PublicNetwork** and a **Compute** into an "**AssignsTo**" relationship between the compute and a **yorc.nodes.google.Address** for Google location
