### PR TITLE
Update instance attributes when node state changed for all states

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -107,6 +107,10 @@ public class EventListenerTask extends AlienTask {
                                         ninfo.put(eInstance, iinfo);
                                     }
                                     orchestrator.updateInstanceState(paasId, eNode, eInstance, iinfo, eState);
+
+                                    // Retrieve instance attribute for all states
+                                    orchestrator.updateInstanceAttributes(paasId, iinfo, eNode, eInstance);
+
                                     switch (eState) {
                                         case "initial":
                                         case "creating":
@@ -121,10 +125,8 @@ public class EventListenerTask extends AlienTask {
                                             ninfo.remove(eInstance);
                                             break;
                                         case "stopped":
-                                            orchestrator.updateInstanceAttributes(paasId, iinfo, eNode, eInstance);
                                             break;
                                         case "started":
-                                            orchestrator.updateInstanceAttributes(paasId, iinfo, eNode, eInstance);
                                             // persist BS Id
                                             String source = jrdi.getDeploymentContext().getDeployment().getSourceName();
                                             if (source.equals("BLOCKSTORAGE_APPLICATION")) {

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -765,8 +765,15 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
                     AttributeResponse attrRes = restClient.getAttributeFromYorc(link.getHref());
                     iinfo.getAttributes().put(attrRes.getName(), attrRes.getValue());
                     log.debug("Attribute: " + attrRes.getName() + "=" + attrRes.getValue());
-                } catch (Exception e) {
-                    log.error("Error getting instance attribute " + link.getHref());
+                } catch (YorcRestException jre){
+                    // attribute can potentially be not found according to the node state
+                    if (jre.getHttpStatusCode() != 404){
+                       log.error("Error getting instance attribute " + link.getHref(), jre);
+                       sendMessage(paasId, "Error getting instance attribute " + link.getHref());
+                    }
+                }
+                catch (Exception e) {
+                    log.error("Error getting instance attribute " + link.getHref(), e);
                     sendMessage(paasId, "Error getting instance attribute " + link.getHref());
                 }
             }


### PR DESCRIPTION
Simple fix to update instance attributes when node state changed for all states
Ignore NotFound Error when attribute can't be resolved according to the node state

Fixes https://github.com/ystia/yorc-a4c-plugin/issues/59
