### PR TITLE
Bugfix/vision topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Vision sample topology upload fails on component version issue ([GH-78](https://github.com/ystia/yorc-a4c-plugin/issues/78))
+
 ## 3.1.0-RC2 (December 18, 2018)
 
 ### DEPENDENCIES

--- a/tosca-samples/org/ystia/yorc/samples/vision/topologies/topology.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/vision/topologies/topology.yaml
@@ -18,7 +18,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: VisionTopology
-  template_version: 0.1.0
+  template_version: 0.1.0-SNAPSHOT
   template_author: yorc
 
 description: >
@@ -27,7 +27,7 @@ description: >
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.0.0
-  - org.ystia.yorc.samples.vision.linux.ansible:1.0.0
+  - org.ystia.yorc.samples.vision.linux.ansible:1.0.0-SNAPSHOT
 
 topology_template:
   inputs:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Updated a component version referenced the topology, to be consistent with the component version changed to be a snapshot version in this Pull Request: https://github.com/ystia/yorc-a4c-plugin/pull/75

### How to verify it

Upload repository `https://github.com/ystia/yorc-a4c-plugin.git` folder `tosca-samples/org/ystia/yorc/samples/vision` branch `bugfix/vision-topology` in Alien4Cloud and check the upload is successful


### Description for the changelog

Vision sample topology upload fails on component version issue ([GH-78](https://github.com/ystia/yorc-a4c-plugin/issues/78))

## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/78

