### PR TITLE
Creating a socketFactoryRegistry so that the system default SSL conte…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Can't connect to Yorc in secure mode  ([GH-81](https://github.com/ystia/yorc-a4c-plugin/issues/81))
+
 ## 3.1.0 (December 20, 2018)
 
 ### BUG FIXES


### PR DESCRIPTION
…xt is used by pools of HttpClientConnections

# Pull Request description

## Description of the change

Fixed an issue attempting to connect to a secured Yorc, where the client certificate was not found, although it was added in a keystore, and java options were set to specify to use this keystore as system default.
Changed the code that was creating a new PoolingHttpClientConnectionManager() without argument,
to use in the secure connection case a new PoolingHttpClientConnectionManager(socketFactoryRegistry), the socketFactoryRegistry being created from a System default SSL context that will take into acount the trustore/keystore specified through java options.

This fix is pushed if any backport is needed.
But the current version of the plugin will implement a new way to specify certificates through the enhancement tracked by https://github.com/ystia/yorc-a4c-plugin/issues/82


### How to verify it

Deploy a secured Yorc.
Add the certificate authority in trustore and client cetificate in keystore.
Edit Alien4Cloud launch script to add java options spcifying the trustore and keystore to use.
Create in Alien4Cloud a Yorc Orchestrator configured with https URL.
Enable it.
Check the enable operation is successful.

### Description for the changelog

Can't connect to Yorc in secure mode  ([GH-81](https://github.com/ystia/yorc-a4c-plugin/issues/81))

## Applicable Issues
https://github.com/ystia/yorc-a4c-plugin/issues/81