### PR TITLE
Add a nanotimestamp field to store raw timestamp (for ordering purpose)

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -103,6 +103,7 @@ public class LogListenerTask extends AlienTask {
         deploymentLog.setType(pLogEvent.getType());
         deploymentLog.setNodeId(pLogEvent.getNodeId());
         deploymentLog.setTimestamp(pLogEvent.getDate());
+        // we use the raw timestamp that is a nanosec precision to ease the sort of logs
         deploymentLog.setRawtimestamp(pLogEvent.getTimestamp());
         deploymentLog.setWorkflowId(pLogEvent.getWorkflowId());
         deploymentLog.setOperationName(pLogEvent.getOperationName());

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -103,6 +103,7 @@ public class LogListenerTask extends AlienTask {
         deploymentLog.setType(pLogEvent.getType());
         deploymentLog.setNodeId(pLogEvent.getNodeId());
         deploymentLog.setTimestamp(pLogEvent.getDate());
+        deploymentLog.setNanotimestamp(pLogEvent.getNanotimestamp());
         deploymentLog.setWorkflowId(pLogEvent.getWorkflowId());
         deploymentLog.setOperationName(pLogEvent.getOperationName());
         deploymentLog.setTaskId(pLogEvent.getAlienTaskId());

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/LogListenerTask.java
@@ -103,7 +103,7 @@ public class LogListenerTask extends AlienTask {
         deploymentLog.setType(pLogEvent.getType());
         deploymentLog.setNodeId(pLogEvent.getNodeId());
         deploymentLog.setTimestamp(pLogEvent.getDate());
-        deploymentLog.setNanotimestamp(pLogEvent.getNanotimestamp());
+        deploymentLog.setRawtimestamp(pLogEvent.getTimestamp());
         deploymentLog.setWorkflowId(pLogEvent.getWorkflowId());
         deploymentLog.setOperationName(pLogEvent.getOperationName());
         deploymentLog.setTaskId(pLogEvent.getAlienTaskId());

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/Response/LogEvent.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/Response/LogEvent.java
@@ -45,4 +45,8 @@ public class LogEvent {
         return Date.from(LocalDateTime.parse(this.getTimestamp(), DateTimeFormatter.ISO_OFFSET_DATE_TIME).atZone(
             ZoneId.systemDefault()).toInstant());
     }
+
+    public Long getNanotimestamp() {
+        return Long.parseLong(this.getTimestamp());
+    }
 }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/Response/LogEvent.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/Response/LogEvent.java
@@ -46,7 +46,4 @@ public class LogEvent {
             ZoneId.systemDefault()).toInstant());
     }
 
-    public Long getNanotimestamp() {
-        return Long.parseLong(this.getTimestamp());
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>alien4cloud</groupId>
     <artifactId>alien4cloud-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <alien4cloud.version>2.1.0</alien4cloud.version>
+    <alien4cloud.version>2.1.1-SNAPSHOT</alien4cloud.version>
     <tosca.normative.types.version>1.0.0-ALIEN20</tosca.normative.types.version>
     <alien4cloud.dsl.version>alien_dsl_2_0_0</alien4cloud.dsl.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>alien4cloud</groupId>
     <artifactId>alien4cloud-parent</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
   </parent>
 
   <properties>
-    <alien4cloud.version>2.1.1-SNAPSHOT</alien4cloud.version>
+    <alien4cloud.version>2.1.1</alien4cloud.version>
     <tosca.normative.types.version>1.0.0-ALIEN20</tosca.normative.types.version>
     <alien4cloud.dsl.version>alien_dsl_2_0_0</alien4cloud.dsl.version>
   </properties>


### PR DESCRIPTION
# Pull Request description

A new field has been added to the PaasDeploymentLog in 2.1.1-SNAPSHOT class in order to store the raw timestamp coming from the orchestrator.

## Description of the change

This change just add a line to set this field when building the object.
