### PR TITLE
Update deployment status with deployment event if status out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BUG FIXES
 
 * Can't connect to Yorc in secure mode  ([GH-81](https://github.com/ystia/yorc-a4c-plugin/issues/81))
+* Deployment status inconsistency when restarting Alien4Cloud and an application finishes to deploy  ([GH-77](https://github.com/ystia/yorc-a4c-plugin/issues/77))
 
 ## 3.1.0 (December 20, 2018)
 

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -145,6 +145,23 @@ public class EventListenerTask extends AlienTask {
                                     }
                                     break;
                                 case EVT_DEPLOYMENT:
+                                    eMessage += event.getType() + ":" + eState;
+                                    log.debug("Received Event from Yorc <<< " + eMessage);
+                                    synchronized (jrdi) {
+                                        jrdi.setLastEvent(event);
+                                        jrdi.notifyAll();
+                                    }
+
+                                    // Check if deployment status needs to be updated with last event
+                                    DeploymentStatus ds = YorcPaaSProvider.getDeploymentStatusFromString(eState.toUpperCase());
+                                    if (! ds.equals(jrdi.getStatus())) {
+                                        log.info(String.format("Seems the current deployment status (%s) is out of date with received deployment event with status (%s) for deploymentID: <%s>. Let's update it.", jrdi.getStatus(), ds, paasId));
+                                        synchronized (jrdi) {
+                                            jrdi.setStatus(ds);
+                                            jrdi.notifyAll();
+                                        }
+                                    }
+                                    break;
                                 case EVT_CUSTOM_COMMAND:
                                 case EVT_SCALING:
                                     eMessage += event.getType() + ":" + eState;

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -857,7 +857,7 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
      * @param state
      * @return
      */
-    private static DeploymentStatus getDeploymentStatusFromString(String state) {
+    protected static DeploymentStatus getDeploymentStatusFromString(String state) {
         switch (state) {
             case "DEPLOYED":
                 return DeploymentStatus.DEPLOYED;


### PR DESCRIPTION
# Pull Request description

## Description of the change
Update deployment status with event listener if current status is different.
This occurs if Alien is restarted during a deployment and the deployment status update (https://github.com/ystia/yorc-a4c-plugin/blob/develop/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java#L227) is done before the deployment ends

### Description for the changelog
* Deployment status inconsistency when restarting Alien4Cloud and an application finishes to deploy  ([GH-77](https://github.com/ystia/yorc-a4c-plugin/issues/77))

## Applicable Issues
fixes #77 
