### PR TITLE
Add compute uninstall on success steps to steps with BS on success un…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Can't connect to Yorc in secure mode  ([GH-81](https://github.com/ystia/yorc-a4c-plugin/issues/81))
 * Deployment status inconsistency when restarting Alien4Cloud and an application finishes to deploy  ([GH-77](https://github.com/ystia/yorc-a4c-plugin/issues/77))
+* Uninstall workflow is not correct for Topology involving BlockStorage node ([GH-90](https://github.com/ystia/yorc-a4c-plugin/issues/90))
 
 ## 3.1.0 (December 20, 2018)
 


### PR DESCRIPTION
…install steps

# Pull Request description


## Description of the change
Add compute uninstall on success steps to steps with BS on success uninstall steps
in order to uninstall compute after  dependent nodes. 


### Description for the changelog
* Uninstall workflow is not correct for Topology involving BlockStorage node ([GH-90](https://github.com/ystia/yorc-a4c-plugin/issues/90))
## Applicable Issues
fixes #90 
