### PR TITLE
Bugfix/gh-45 Deploying applications simultaneously can fail on invalid zip error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Upgrade to Alien4Cloud 2.1.1
 
+### BUG FIXES
+
+* Deploying applications simultaneously can fail on invalid zip error ([GH-45](https://github.com/ystia/yorc-a4c-plugin/issues/45))
+
 ## 3.2.0-M1 (January 28, 2019)
 
 ### BUG FIXES

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
@@ -227,11 +227,12 @@ public class RestClient {
     /**
      * Send a topology to Yorc
      * @param deploymentId
+     * @param archiveName
      * @return String
      * @throws Exception
      */
-    public String sendTopologyToYorc(String deploymentId) throws Exception {
-        try (InputStream stream = new FileInputStream(new File("topology.zip")))
+    public String sendTopologyToYorc(String deploymentId, String archiveName) throws Exception {
+        try (InputStream stream = new FileInputStream(new File(archiveName)))
         {
             // Get file to upload
             final byte[] bytes = new byte[stream.available()];


### PR DESCRIPTION
# Pull Request description

## Description of the change

Removed a block `synchronized(this)` that was created to protect the creation of a file named topology.zip for each deployment,`this` being an instance of DeployTask.
We can have several instances of DeployTask running in parallel, so they would not be blocked by the `synchronized(this)` and could then write on the same file.

Instead, creating a file `deployment PAAS ID`-toplogy.zip to ensure the filename created for the application to deploy is unique.



### Tests

Tried several times to deploy nearly simultaneously (through the REST API) 9 applications, checked there was no deployment failure.

### Description for the changelog

Deploying applications simultaneously can fail on invalid zip error ([GH-45](https://github.com/ystia/yorc-a4c-plugin/issues/45))

## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/45