### PR TITLE
update docker-types to 2.1.1

### DIFF
--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/components/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/components/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 description: Contains types for testing Jobs in Kubernetes
 

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/compute_pi/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/compute_pi/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/fail/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/fail/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/loop/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/loop/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/kube/apache/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/apache/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 description: Apacahe Docker that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/containers/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/containers/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 description: DockerContainers that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/grafana/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/grafana/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 description: Grafana and graphite containers that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/monitoring/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/monitoring/types.yaml
@@ -11,7 +11,7 @@ description: |
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.grafana:1.0.0-SNAPSHOT
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-emptydir/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-emptydir/types.yaml
@@ -10,7 +10,7 @@ description: "Test emptyDir volumes on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-hostPath/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-hostPath/types.yaml
@@ -10,7 +10,7 @@ description: "Test hostPath volumes on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache/types.yaml
@@ -10,7 +10,7 @@ description: "Test Apache exposed as service on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/wordpress/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/wordpress/types.yaml
@@ -10,7 +10,7 @@ description: ""
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.containers:1.0.0-SNAPSHOT
-  - docker-types:2.1.0
+  - docker-types:2.1.1
 
 topology_template:
   node_templates:


### PR DESCRIPTION
# Pull Request description

## Description of the change
Updated depencies on docker-types to v2.1.1

### Description for the change log
In Tosca-samples for kubernetes, updated depencies to docker-types v2.1.1 ([GH-93](https://github.com/ystia/yorc-a4c-plugin/issues/93))

## Applicable Issues
https://github.com/ystia/yorc-a4c-plugin/issues/93