### PR TITLE
Backport of fix for GH-45 on invalid zip error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Can't connect to Yorc in secure mode  ([GH-81](https://github.com/ystia/yorc-a4c-plugin/issues/81))
 * Deployment status inconsistency when restarting Alien4Cloud and an application finishes to deploy  ([GH-77](https://github.com/ystia/yorc-a4c-plugin/issues/77))
+* Deploying applications simultaneously can fail on invalid zip error ([GH-45](https://github.com/ystia/yorc-a4c-plugin/issues/45))
 
 ## 3.1.0 (December 20, 2018)
 

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
@@ -227,11 +227,12 @@ public class RestClient {
     /**
      * Send a topology to Yorc
      * @param deploymentId
+     * @param archiveName
      * @return String
      * @throws Exception
      */
-    public String sendTopologyToYorc(String deploymentId) throws Exception {
-        try (InputStream stream = new FileInputStream(new File("topology.zip")))
+    public String sendTopologyToYorc(String deploymentId, String archiveName) throws Exception {
+        try (InputStream stream = new FileInputStream(new File(archiveName)))
         {
             // Get file to upload
             final byte[] bytes = new byte[stream.available()];


### PR DESCRIPTION
# Pull Request description

Backport to 3.1 of pull request https://github.com/ystia/yorc-a4c-plugin/pull/92 addressing issue https://github.com/ystia/yorc-a4c-plugin/issues/45 : Deploying 2 applications simultaneously failed on invalid zip error.

## Description of the change

Removed a block `synchronized(this)` that was created to protect the creation of a file named topology.zip for each deployment,`this` being an instance of DeployTask.
We can have several instances of DeployTask running in parallel, so they would not be blocked by the `synchronized(this)` and could then write on the same file.

Instead, creating a file `deployment PAAS ID`-toplogy.zip to ensure the filename created for the application to deploy is unique.


## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/45