### PR TITLE
Bugfix/gh 110 undeployment in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Application undeployment seen in progress until timeout of 30 minutes occurs ([GH-110](https://github.com/ystia/yorc-a4c-plugin/issues/110))
+
+
 ## 3.2.0-M3 (March 11, 2019)
 
 ### FEATURES

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
@@ -163,6 +163,7 @@ public class UndeployTask extends AlienTask {
                     long remainingTime = timeout - System.currentTimeMillis();
                     if (remainingTime <= 0) {
                         log.warn("Timeout occured");
+                        error = new Exception("Undeployment failed on timeout");
                         break;
                     }
                     try {

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
@@ -144,6 +144,7 @@ public class UndeployTask extends AlienTask {
                         log.debug("Undeployment OK");
                         // Undeployment OK.
                         orchestrator.changeStatus(paasId, DeploymentStatus.UNDEPLOYED);
+                        done = true;
                         break;
                     case "INITIAL":
                         // No event will be received, and the undeployment should be straightforward
@@ -152,6 +153,10 @@ public class UndeployTask extends AlienTask {
                     default:
                         log.debug("Deployment Status is currently " + status);
                         break;
+                }
+                if (done) {
+                    // No need to wait for an event, the status is already undeployed
+                    break;
                 }
                 // Wait an Event from Yorc or timeout
                 synchronized (jrdi) {
@@ -207,8 +212,8 @@ public class UndeployTask extends AlienTask {
 
         // Return result to a4c
         if (error == null) {
-            callback.onSuccess(null);
             orchestrator.removeDeploymentInfo(paasId);
+            callback.onSuccess(null);
         } else {
             callback.onFailure(error);
         }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
@@ -108,8 +108,14 @@ public class UndeployTask extends AlienTask {
         }
 
         if (!done && error == null) {
-            String taskId = taskUrl.substring(taskUrl.lastIndexOf("/") + 1);
-            orchestrator.sendMessage(paasId, "Undeployment sent to Yorc. taskId=" + taskId);
+            if (taskUrl != null) {
+                try {
+                    String taskId = taskUrl.substring(taskUrl.lastIndexOf("/") + 1);
+                    orchestrator.sendMessage(paasId, "Undeployment sent to Yorc. taskId=" + taskId);
+                } catch (Exception ex) {
+                    log.error("Failed to get undeployment task ID from URL: " + taskUrl);
+                }
+            }
 
             // wait for Yorc undeployment completion
             long timeout = System.currentTimeMillis() + YORC_UNDEPLOY_TIMEOUT;

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UndeployTask.java
@@ -32,6 +32,7 @@ public class UndeployTask extends AlienTask {
     IPaaSCallback<?> callback;
 
     private final int YORC_UNDEPLOY_TIMEOUT = 1000 * 60 * 30;  //  30 mn
+    private final int WAIT_EVENT_TIMEOUT = 1000 * 30; // 30 seconds
 
     public UndeployTask(PaaSDeploymentContext ctx, YorcPaaSProvider prov, IPaaSCallback<?> callback) {
         super(prov);
@@ -57,7 +58,7 @@ public class UndeployTask extends AlienTask {
                 try {
                     restClient.stopTask(deploymentUrl + "/tasks/" + jrdi.getDeployTaskId());
                     // do not wait more than 30 sec.
-                    jrdi.wait(1000 * 30);
+                    jrdi.wait(WAIT_EVENT_TIMEOUT);
                 } catch (Exception e) {
                     log.error("stopTask returned an exception", e);
                 }
@@ -154,13 +155,25 @@ public class UndeployTask extends AlienTask {
                 }
                 // Wait an Event from Yorc or timeout
                 synchronized (jrdi) {
-                    long timetowait = timeout - System.currentTimeMillis();
-                    if (timetowait <= 0) {
+                    long remainingTime = timeout - System.currentTimeMillis();
+                    if (remainingTime <= 0) {
                         log.warn("Timeout occured");
                         break;
                     }
                     try {
-                        jrdi.wait(timetowait);
+                        // Not waiting for the overall remaining time here,
+                        // as the plugin may never be notified of the undeployment
+                        // if Yorc purge has deleted all events before clients
+                        // listening to events were notified.
+                        // Waiting for a shorter time here.
+                        // If no event is received, we'll go back at the beginning
+                        // of the loop and check the deployment existence and status
+                        // and wait again here if needed
+                        long waitTime = WAIT_EVENT_TIMEOUT;
+                        if (waitTime >  remainingTime) {
+                            waitTime = remainingTime;
+                        }
+                        jrdi.wait(waitTime);
                     } catch (InterruptedException e) {
                         log.error("Interrupted while waiting for undeployment");
                         break;


### PR DESCRIPTION
# Pull Request description

## Description of the change

The undeploy task could wait for 30 minutes for an application undeployed status change event that could never come if Yorc had purged events related to the application in Consul before Consul could wake up clients polling for these events.

### What I did

Updated the loop waiting for the undeployed status to:
  * not wait if the status is already undeployed (done=true line 147, and break from loop line 157)
  * wait for 30 seconds instead of 30 minutes, and if no undeployed event was received go back to the beginning of the loop, the loop will check again if the application still exists before waiting again.
  * fail on error after 30 minutes (line 166) if the application wasn't undeployed yet
  * once the application is undeployed, remove it from the orchestrator before calling Alien4Cloud call back on success (line 217)


### How to verify it

Create n basic applications in Alien4cloud, containing just a Compute node.
Select to deploy them on a HostsPool having an on-demand Compute resource that is shareable.

Once these n applications are ready to be deployed, use the Alien4Cloud REST API to deploy all these applications.
For example to deploy an application:

```bash 
$ appname=MyApp1
$ appenvid=4cb40aa9-23c2-42a6-ab7b-e81c7aa1680e
$ curl --insecure --request POST \
 --url  $a4cURL/rest/latest/applications/deployment \
 --header 'content-type: application/json' \
 --cookie cookies.a4c \
 --silent \
 --data "{\"applicationId\": \"$appname\", \"applicationEnvironmentId\": \"$appenvid\"}"
```

Once all applications are deployed, undeploy all of them :
 
```bash
$ curl --insecure --request DELETE \
 --url $a4cURL/rest/v1/applications/$appname/environments/$appenvid/deployment \
 --header 'accept: application/json' --header 'content-type: application/json' \
 --silent \
 --cookie cookies.a4c
```

Check in Alien4Cloud UI that all applications switched to state UNDEPLOYED in less than a minute.

### Description for the changelog

Application undeployment seen in progress until timeout of 30 minutes occurs ([GH-110](https://github.com/ystia/yorc-a4c-plugin/issues/110))

## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/110
