### PR TITLE
Feature/gh 112 deployment update workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Deployment update: support the ability to add/remove workflows with Yorc Premium version ([GH-112](https://github.com/ystia/yorc-a4c-plugin/issues/112))
+
 ### BUG FIXES
 
 * Application undeployment seen in progress until timeout of 30 minutes occurs ([GH-110](https://github.com/ystia/yorc-a4c-plugin/issues/110))

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
@@ -95,14 +95,21 @@ public class DeployTask extends AlienTask {
      * Execute the Deployment
      */
     public void run() {
-        Throwable error = null;
 
         // Keep Ids in a Map
         String paasId = ctx.getDeploymentPaaSId();
         String alienId = ctx.getDeploymentId();
-        String deploymentUrl = "/deployments/" + paasId;
-        log.debug("Deploying " + paasId + "with id : " + alienId);
         orchestrator.putDeploymentId(paasId, alienId);
+
+        log.info("Deploying " + paasId + "with id : " + alienId);
+        deploy(paasId, alienId);
+    }
+
+    protected void deploy(String paasId, String alienId) {
+
+        Throwable error = null;
+
+        String deploymentUrl = "/deployments/" + paasId;
 
         // Init Deployment Info from topology
         DeploymentTopology dtopo = ctx.getDeploymentTopology();
@@ -133,11 +140,12 @@ public class DeployTask extends AlienTask {
         }
 
         // Send topology zip to Yorc
-        log.info("Sending Topology " + ctx.getDeploymentPaaSId() + " to Yorc");
+        log.info("Sending Topology " + paasId + " to Yorc");
         String taskUrl;
         try {
             taskUrl = restClient.sendTopologyToYorc(paasId, zipName);
         } catch (Exception e) {
+            log.error("Yorc returned an error for topology " + paasId + " : " + e.getMessage());
             orchestrator.sendMessage(paasId, "Deployment not accepted by Yorc: " + e.getMessage());
             orchestrator.doChangeStatus(paasId, DeploymentStatus.FAILURE);
             callback.onFailure(e);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ystia.yorc.alien4cloud.plugin;
+
+
+import alien4cloud.component.ICSARRepositorySearchService;
+import alien4cloud.paas.IPaaSCallback;
+import alien4cloud.paas.model.PaaSTopologyDeploymentContext;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Update deployment task
+ */
+@Slf4j
+public class UpdateTask extends DeployTask {
+
+    public UpdateTask(PaaSTopologyDeploymentContext ctx, YorcPaaSProvider prov, IPaaSCallback<?> callback,
+            ICSARRepositorySearchService csarRepoSearchService) {
+        super(ctx, prov, callback, csarRepoSearchService);
+    }
+
+    /**
+     * Update the Deployment
+     */
+    public void run() {
+        String paasId = ctx.getDeploymentPaaSId();
+        String alienId = ctx.getDeploymentId();
+
+        log.info("Updating deployment" + paasId + "with id : " + alienId);
+        deploy(paasId, alienId);
+    }
+}

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
@@ -18,6 +18,7 @@ package org.ystia.yorc.alien4cloud.plugin;
 
 import alien4cloud.component.ICSARRepositorySearchService;
 import alien4cloud.paas.IPaaSCallback;
+import alien4cloud.paas.model.DeploymentStatus;
 import alien4cloud.paas.model.PaaSTopologyDeploymentContext;
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,4 +43,11 @@ public class UpdateTask extends DeployTask {
         log.info("Updating deployment" + paasId + "with id : " + alienId);
         deploy(paasId, alienId);
     }
+
+    // Overriding parent class method to set a UPDATE_FAILURE status
+    // when the operation fails before even being run by the orchestrator
+    protected void changeStatusToFailure(String paasId) {
+        orchestrator.doChangeStatus(paasId, DeploymentStatus.UPDATE_FAILURE);
+    }
+
 }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java
@@ -15,8 +15,8 @@
  */
 package org.ystia.yorc.alien4cloud.plugin;
 
-
 import alien4cloud.component.ICSARRepositorySearchService;
+import alien4cloud.model.deployment.DeploymentTopology;
 import alien4cloud.paas.IPaaSCallback;
 import alien4cloud.paas.model.DeploymentStatus;
 import alien4cloud.paas.model.PaaSTopologyDeploymentContext;
@@ -48,6 +48,16 @@ public class UpdateTask extends DeployTask {
     // when the operation fails before even being run by the orchestrator
     protected void changeStatusToFailure(String paasId) {
         orchestrator.doChangeStatus(paasId, DeploymentStatus.UPDATE_FAILURE);
+    }
+
+    // Overriding parent class method
+    protected YorcRuntimeDeploymentInfo setupDeploymentInfo(
+        DeploymentTopology dtopo, String paasId, String deploymentURL) {
+
+        // Here for an update, the deployment info has already been created
+        // and doesn' need to be updated in the current implementation
+        // where the only update supported is the update of workflows
+        return orchestrator.getDeploymentInfo(paasId);
     }
 
 }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -257,7 +257,7 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
      * @param callback to call when update is done or has failed.
      */
     public void update(PaaSTopologyDeploymentContext ctx, IPaaSCallback<?> callback) {
-        callback.onFailure(new UnsupportedOperationException("update topology not supported in Yorc"));
+        addTask(new UpdateTask(ctx, this, callback, csarRepoSearchService));
     }
 
     /**

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcPaaSProvider.java
@@ -795,24 +795,42 @@ public class YorcPaaSProvider implements IOrchestratorPlugin<ProviderConfig> {
      * @return
      */
     protected static DeploymentStatus getDeploymentStatusFromString(String state) {
+        DeploymentStatus deploymentStatus;
         switch (state) {
             case "DEPLOYED":
-                return DeploymentStatus.DEPLOYED;
+                deploymentStatus = DeploymentStatus.DEPLOYED;
+                break;
             case "UNDEPLOYED":
-                return DeploymentStatus.UNDEPLOYED;
+                deploymentStatus = DeploymentStatus.UNDEPLOYED;
+                break;
             case "DEPLOYMENT_IN_PROGRESS":
             case "SCALING_IN_PROGRESS":
-                return DeploymentStatus.DEPLOYMENT_IN_PROGRESS;
+                deploymentStatus = DeploymentStatus.DEPLOYMENT_IN_PROGRESS;
+                break;
             case "UNDEPLOYMENT_IN_PROGRESS":
-                return DeploymentStatus.UNDEPLOYMENT_IN_PROGRESS;
+                deploymentStatus = DeploymentStatus.UNDEPLOYMENT_IN_PROGRESS;
+                break;
             case "INITIAL":
-                return DeploymentStatus.INIT_DEPLOYMENT;
+                deploymentStatus = DeploymentStatus.INIT_DEPLOYMENT;
+                break;
             case "DEPLOYMENT_FAILED":
             case "UNDEPLOYMENT_FAILED":
-                return DeploymentStatus.FAILURE;
+                deploymentStatus = DeploymentStatus.FAILURE;
+                break;
+            case "UPDATE_IN_PROGRESS":
+                deploymentStatus = DeploymentStatus.UPDATE_IN_PROGRESS;
+                break;
+            case "UPDATED":
+                deploymentStatus = DeploymentStatus.UPDATED;
+                break;
+            case "UPDATE_FAILURE":
+                deploymentStatus = DeploymentStatus.UPDATE_FAILURE;
+                break;
             default:
-                return DeploymentStatus.UNKNOWN;
+                deploymentStatus =  DeploymentStatus.UNKNOWN;
         }
+
+        return deploymentStatus;
     }
 
 

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/rest/RestClient.java
@@ -346,7 +346,8 @@ public class RestClient {
 
             String targetUrl = providerConfiguration.getUrlYorc() + "/deployments/" + deploymentId;
             ResponseEntity<String> resp = sendRequest(targetUrl, HttpMethod.PUT, String.class, request);
-            if (!resp.getStatusCode().getReasonPhrase().equals("Created")){
+            if (!resp.getStatusCode().getReasonPhrase().equals("Created") &&
+                !resp.getStatusCode().getReasonPhrase().equals("OK")) {
                 throw new Exception("sendTopologyToYorc: Yorc returned an unexpected status: " + resp.getStatusCode().getReasonPhrase());
             }
             return resp.getHeaders().getFirst("Location");


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added a task sending the deployment update request to the orchestrator.

### What I did

Added a task `alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/UpdateTask.java` asking Yorc to perform a deployment update.

This task is a child of the already existing `DeployTask`, as it will re-use `DeployTask.deploy()` method, the only differences between UpdateTask and DeployTask being :
  * the failure status to return if the operation failed even before Yorc could be called to perform the operation, code implemented in method `DeployTask.changeStatusToFailure()` and overriden in `UpdateTask`
  * the need or not to create an object containing details on each node template initialized with a status `DeploymentStatus.INIT_DEPLOYMENT`, needed in `DeployTask`, not needed in `UpdateTask` which today does not modify node templates but just workflows and so can re-use the object already created, code implemented in method `DeployTask.setupDeploymentInfo()` and overriden in `UpdateTask`.


### How to verify it

Follow Yorc premium version pull request howto demo guide.
If you are using this plugin and a Yorc premium version, the update should succeed.
If you are using this plugin and Yorc open source, the update operation should fail, and logs should report the error reported by the Orchestrator, which is: the update is supported in premium version only.  

### Description for the changelog

Deployment update: support the ability to add/remove workflows with Yorc Premium version ([GH-112](https://github.com/ystia/yorc-a4c-plugin/issues/112))

## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/112