### PR TITLE
Bugfix/gh 117 scale down  instance state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Implement an anti-affinity placement policy for Openstack ([GH-84](https://github.com/ystia/yorc/issues/84))
 
+### BUG FIXES
+
+* Scale Down operation never ending with compute instance final status 'Initial' ([GH-117](https://github.com/ystia/yorc-a4c-plugin/issues/117))
+
+
 ## 3.2.0-M4 (March 29, 2019)
 
 ### FEATURES


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue where after a 'Scale Down' operation, the deleted compute instance was still there in Alien4cloud with its final status appearing as `Initial`, although the instance was effectively deleted in the infrastructure and in the orchestrator.

Cause of this issue:
After an instance deleted event was received, the plugin removed its java object representing the compute instance.
Then an attribute change notification was received to notify the compute instance attribute `state` changed its value to `deleted`.
The plugin code managing this notification, seeing there was no such java object for this instance, was erroneously recreating the java object previously deleted, with the instance state initialized to `Initial`.

### What I did

When an attribute change notification is received to notify an instance attribute `state` changed its value to `deleted`,
the plugin is now just notifying Alien4Cloud, it won't create a java object for this instance contrarily to what it did before.

### How to verify it

Create an application with a scalable compute instance having 2 instances by default.
Deploy it.
Once deployed, scale it down to 1 instance.
Check the operation is done and check that one compute instance disappears from Alien4Cloud.

### Description for the changelog

Scale Down operation never ending with compute instance final status 'Initial' ([GH-117](https://github.com/ystia/yorc-a4c-plugin/issues/117))

## Applicable Issues

https://github.com/ystia/yorc-a4c-plugin/issues/117