### PR TITLE
Manage states that correspond to k8s and slurm job new status in Even…

### DIFF
--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -136,6 +136,18 @@ public class EventListenerTask extends AlienTask {
                                         case "error":
                                             log.warn("Error instance status in deploymentID: {} and nodeID: {}", paasId, eNode);
                                             break;
+                                        case "running":
+                                        case "pending":
+                                        case "failed":
+                                        case "succeeded":
+                                        case "unknown":
+                                        case "No pods created":
+                                        case "completed":
+                                        case "completing":
+                                        case "signaling":
+                                        case "resizing":
+                                            // currently managed states that correspond to k8s and slurm job statuses
+                                            break;
                                         default:
                                             log.warn("Unknown instance status: " + eState);
                                             break;

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -136,6 +136,10 @@ public class EventListenerTask extends AlienTask {
                                         case "error":
                                             log.warn("Error instance status in deploymentID: {} and nodeID: {}", paasId, eNode);
                                             break;
+                                        case "submitting":
+                                        case "submitted":
+                                        case "executing":
+                                        case "executed":
                                         case "running":
                                         case "pending":
                                         case "failed":

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -110,19 +110,8 @@ public class EventListenerTask extends AlienTask {
                                     }
                                     orchestrator.updateInstanceState(paasId, eNode, eInstance, iinfo, eState);
                                     switch (eState) {
-                                        case "initial":
-                                        case "creating":
-                                        case "deleting":
-                                        case "starting":
-                                        case "stopping":
-                                        case "configured":
-                                        case "configuring":
-                                        case "created":
-                                            break;
                                         case "deleted":
                                             ninfo.remove(eInstance);
-                                            break;
-                                        case "stopped":
                                             break;
                                         case "started":
                                             // persist BS Id
@@ -136,24 +125,7 @@ public class EventListenerTask extends AlienTask {
                                         case "error":
                                             log.warn("Error instance status in deploymentID: {} and nodeID: {}", paasId, eNode);
                                             break;
-                                        case "submitting":
-                                        case "submitted":
-                                        case "executing":
-                                        case "executed":
-                                        case "running":
-                                        case "pending":
-                                        case "failed":
-                                        case "succeeded":
-                                        case "unknown":
-                                        case "No pods created":
-                                        case "completed":
-                                        case "completing":
-                                        case "signaling":
-                                        case "resizing":
-                                            // currently managed states that correspond to k8s and slurm job statuses
-                                            break;
                                         default:
-                                            log.warn("Unknown instance status: " + eState);
                                             break;
                                     }
                                     break;


### PR DESCRIPTION
# Pull Request description
Manage new states corresponding to k8s and slurm job statuses
This is needed because the choise was made to use the instances 'state' attribute for jobs statuses.

Maybe we should simplify the state management for instance events for 2 reasons :

- there are to many possible states for different job implementations (slurm, k8S, etc.)
- these states are not really used by A4C 

## Description of the change

Only manage instance state values that need some specific action (started, error and delete)
### What I did

### How I did it

### How to verify it

### Description for the changelog

## Applicable Issues
