### PR TITLE
Update Alien version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Can be used within Alien 2.2.0
+
 ## 3.2.0 (May 31, 2019)
 
 ### BUG FIXES

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/DeployTask.java
@@ -112,7 +112,7 @@ public class DeployTask extends AlienTask {
         DeploymentTopology dtopo, String paasId, String deploymentURL) {
 
         Map<String, Map<String, InstanceInformation>> curinfo = setupInstanceInformations(dtopo);
-        YorcRuntimeDeploymentInfo jrdi = new YorcRuntimeDeploymentInfo(ctx, DeploymentStatus.INIT_DEPLOYMENT, curinfo, deploymentURL);
+        YorcRuntimeDeploymentInfo jrdi = new YorcRuntimeDeploymentInfo(DeploymentStatus.INIT_DEPLOYMENT, curinfo, deploymentURL);
         orchestrator.putDeploymentInfo(paasId, jrdi);
         orchestrator.doChangeStatus(paasId, DeploymentStatus.INIT_DEPLOYMENT);
         return jrdi;

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -114,13 +114,18 @@ public class EventListenerTask extends AlienTask {
                                             ninfo.remove(eInstance);
                                             break;
                                         case "started":
+                                            // Support Alien4Cloud 2.2.0
+                                            // TODO
+                                            // How can we get the Deployment's source name (the application name as we don't have
+                                            // anymore in jrdi the full deployment context ???
                                             // persist BS Id
+                                            /*
                                             String source = jrdi.getDeploymentContext().getDeployment().getSourceName();
                                             if (source.equals("BLOCKSTORAGE_APPLICATION")) {
                                                 PaaSInstancePersistentResourceMonitorEvent prme = new PaaSInstancePersistentResourceMonitorEvent(eNode, eInstance,
                                                         MapUtil.newHashMap(new String[]{NormativeBlockStorageConstants.VOLUME_ID}, new Object[]{UUID.randomUUID().toString()}));
                                                 orchestrator.postEvent(prme, paasId);
-                                            }
+                                            }*/
                                             break;
                                         case "error":
                                             log.warn("Error instance status in deploymentID: {} and nodeID: {}", paasId, eNode);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcRuntimeDeploymentInfo.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YorcRuntimeDeploymentInfo.java
@@ -31,8 +31,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class YorcRuntimeDeploymentInfo {
     @NonNull
-    private PaaSTopologyDeploymentContext deploymentContext;
-    @NonNull
     private DeploymentStatus status;
     /**
      * Represents the status of every instance of node templates currently deployed.

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/YstiaOrchestratorFactory.java
@@ -43,7 +43,7 @@ public class YstiaOrchestratorFactory implements IOrchestratorPluginFactory<Yorc
     private BeanFactory beanFactory;
 
     @Override
-    public YorcPaaSProvider newInstance() {
+    public YorcPaaSProvider newInstance(ProviderConfig config) {
         return beanFactory.getBean(YorcPaaSProvider.class);
     }
 
@@ -87,6 +87,5 @@ public class YstiaOrchestratorFactory implements IOrchestratorPluginFactory<Yorc
     public String getType() {
         return "Ystia Orchestrator";
     }
-
 
 }

--- a/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_component_input.yaml
+++ b/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_component_input.yaml
@@ -92,7 +92,7 @@ capability_types:
         default: false
       url_path:
         type: string
-        description: The optional URL path of the endpoint’s address if applicable for the protocol.
+        description: The optional URL path of the endpoint's address if applicable for the protocol.
         required: false
       port_name:
         type: string
@@ -122,7 +122,7 @@ capability_types:
     attributes:
       ip_address:
         type: string
-        description: This is the IP address as propagated up by the associated node’s host (Compute) container.
+        description: This is the IP address as propagated up by the associated node's host (Compute) container.
 
 node_types:
   org.yorc.samples.python.Component:

--- a/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_component_output.yaml
+++ b/alien4cloud-yorc-plugin/src/test/resources/org/ystia/yorc/alien4cloud/plugin/tosca/tosca_component_output.yaml
@@ -82,7 +82,7 @@ capability_types:
         default: false
       url_path:
         type: string
-        description: "The optional URL path of the endpoint’s address if applicable for the protocol."
+        description: "The optional URL path of the endpoint's address if applicable for the protocol."
         required: false
       port_name:
         type: string
@@ -100,7 +100,7 @@ capability_types:
     attributes:
       ip_address:
         type: string
-        description: "This is the IP address as propagated up by the associated node’s host (Compute) container."
+        description: "This is the IP address as propagated up by the associated node's host (Compute) container."
 
 node_types:
   org.yorc.samples.python.Component:

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <properties>
-    <alien4cloud.version>2.1.1</alien4cloud.version>
+    <alien4cloud.version>2.2.0-SM6</alien4cloud.version>
     <tosca.normative.types.version>1.0.0-ALIEN20</tosca.normative.types.version>
     <alien4cloud.dsl.version>alien_dsl_2_0_0</alien4cloud.dsl.version>
   </properties>


### PR DESCRIPTION
## Description of the change
Support Alien4Cloud version 2.2.0-SM6

### What I did
Updated alien4cloud.version in parent pom.xml
Modify YorcPaasProvider and take into account the fact that Alien does not provide anymore to the orchestrator the PaasTopologyDeploymentContext in the init method.
So this context is not available anymore in the YorcRuntimeDeploymentInfo (jrdi) data structure. This has a direct effect on the switchMaintenanceMode method's implementation, and  on the EventListnertask and DeployTask.

### How to verify it
Install an Alien 2.2.0-SM6 (http://10.197.135.244/starlings/alien4cloud/alien4cloud-premium-dist-2.2.0-SM6-dist.tar.gz) and replace alien4cloud-yorc-provider by alien4cloud-yorc-plugin corresponding to this PR.

### Description for the changelog

## Applicable Issues
