### PR TITLE
Remove timeout for workflow execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### BUG FIXES
 
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
+* Workflow ends with timeout after 4 hours and application is undeployed ([GH-131](https://github.com/ystia/yorc-a4c-plugin/issues/131))
 
 ## 3.2.0 (May 31, 2019)
 

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/EventListenerTask.java
@@ -165,6 +165,7 @@ public class EventListenerTask extends AlienTask {
                                     eMessage += event.getType() + ":" + eState;
                                     log.debug("Received Event from Yorc <<< " + eMessage);
                                     synchronized (jrdi) {
+                                        jrdi.setLastEvent(event);
                                         jrdi.notifyAll();
                                     }
                                     switch (event.getStatus()) {

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
@@ -32,8 +32,6 @@ public class WorkflowTask extends AlienTask {
     IPaaSCallback<?> callback;
     String workflowName;
     Map<String, Object> inputs;
-
-    private final int YORC_OPE_TIMEOUT = 1000 * 3600 * 4;  // 4 hours
     
     public WorkflowTask(PaaSDeploymentContext ctx, YorcPaaSProvider prov, String workflowName, Map<String, Object> inputs, IPaaSCallback<?> callback) {
         super(prov);
@@ -68,26 +66,7 @@ public class WorkflowTask extends AlienTask {
 
         // wait for end of task
         boolean done = false;
-        long timeout = System.currentTimeMillis() + YORC_OPE_TIMEOUT;
-        Event evt;
         while (!done && error == null) {
-            synchronized (jrdi) {
-                // Check deployment timeout
-                long timetowait = timeout - System.currentTimeMillis();
-                if (timetowait <= 0) {
-                    log.warn("Deployment Timeout occured");
-                    error = new Throwable("Deployment timeout");
-                    orchestrator.doChangeStatus(paasId, DeploymentStatus.FAILURE);
-                    break;
-                }
-                // Wait Deployment Events from Yorc
-                log.debug(paasId + ": Waiting for deployment events.");
-                try {
-                    jrdi.wait(timetowait);
-                } catch (InterruptedException e) {
-                    log.warn("Interrupted while waiting for deployment");
-                }
-            }
             // We were awaken for some bad reason or a timeout
             // Check Task Status to decide what to do now.
             String status;


### PR DESCRIPTION
# Pull Request description

## Description of the change
Remove timeout for workflow
Use workflow event notification to set workflow status

### How to verify it
Run a job with time execution > 4h

### Description for the changelog
* Workflow ends with timeout after 4 hours and application is undeployed  ([GH-131](https://github.com/ystia/yorc-a4c-plugin/issues/131))
## Applicable Issues
#131 