### PR TITLE
Bugfix/gh 134 alien22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### BUG FIXES
 
+* Update TOSCA samples to use Alien4Cloud 2.2 types  ([GH-134](https://github.com/ystia/yorc-a4c-plugin/issues/134))
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
 * Workflow ends with timeout after 4 hours and application is undeployed ([GH-131](https://github.com/ystia/yorc-a4c-plugin/issues/131))
 

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/components/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/components/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 description: Contains types for testing Jobs in Kubernetes
 

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/compute_pi/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/compute_pi/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/fail/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/fail/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/loop/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/k8s/topologies/loop/types.yaml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
   - org.ystia.yorc.samples.kube.jobs:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/noscheduler/components/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/noscheduler/components/types.yaml
@@ -26,7 +26,7 @@ description: |
   
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-types:1.1.0
 
 node_types:

--- a/tosca-samples/org/ystia/yorc/samples/job/noscheduler/topologies/chainedJobs/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/job/noscheduler/topologies/chainedJobs/types.yaml
@@ -12,7 +12,7 @@ description: |
 imports:
   - yorc-types:1.1.0
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - org.ystia.yorc.samples.job.noscheduler.Components:1.0.0-SNAPSHOT
 
 topology_template:

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/bash_loop/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/bash_loop/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - org.ystia.yorc.samples.job.slurm.singularity.components:1.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/compute_pi/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/compute_pi/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - org.ystia.yorc.samples.job.slurm.singularity.components:1.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/hello/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/hello/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - org.ystia.yorc.samples.job.slurm.singularity.components:1.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/lolcow/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/lolcow/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - org.ystia.yorc.samples.job.slurm.singularity.components:1.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/mnist/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/singularity/topologies/mnist/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - org.ystia.yorc.samples.job.slurm.singularity.mnist:1.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/tosca-samples/org/ystia/yorc/samples/job/slurm/topologies/demo/types.yml
+++ b/tosca-samples/org/ystia/yorc/samples/job/slurm/topologies/demo/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.1.1
+  - alien-base-types:2.2.0-SM6
   - yorc-slurm-types:1.2.0
   - yorc-types:1.1.0
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/apache/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/apache/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 description: Apacahe Docker that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/containers/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/containers/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 description: DockerContainers that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/grafana/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/grafana/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 description: Grafana and graphite containers that can be deployed on K8S
 

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/monitoring/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/monitoring/types.yaml
@@ -11,7 +11,7 @@ description: |
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.grafana:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-emptydir/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-emptydir/types.yaml
@@ -10,7 +10,7 @@ description: "Test emptyDir volumes on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-hostPath/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache-hostPath/types.yaml
@@ -10,7 +10,7 @@ description: "Test hostPath volumes on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-apache/types.yaml
@@ -10,7 +10,7 @@ description: "Test Apache exposed as service on k8s"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.apache:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-yorc/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/simple-yorc/types.yaml
@@ -10,7 +10,7 @@ description: "A simple yorc server"
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.yorc:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/topology/wordpress/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/topology/wordpress/types.yaml
@@ -10,7 +10,7 @@ description: ""
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.samples.kube.containers:1.0.0-SNAPSHOT
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 topology_template:
   node_templates:

--- a/tosca-samples/org/ystia/yorc/samples/kube/yorc/types.yaml
+++ b/tosca-samples/org/ystia/yorc/samples/kube/yorc/types.yaml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 description: Yorc Docker that can be deployed on K8S
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Updated in tosca samples versions of types brought by Alien4Cloud from 2.1.1 to 2.2.0-SM6.

### How to verify it

Bootstrap a yorc 4.0.0 setup.
In Alien4Cloud UI, create a slurm location (to load associated types)
Upload git repository `https://github.com/ystia/yorc-a4c-plugin.git`, branch `bugfix/GH-134-alien22`, directory `tosca-samples`.

Check the upload is successful.

### Description for the changelog

Update TOSCA samples to use Alien4Cloud 2.2 types  ([GH-134](https://github.com/ystia/yorc-a4c-plugin/issues/134))

## Applicable Issues

Fixes #134 