### PR TITLE
Feature/gh 136 rest api secured a4c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@
 
 ### ENHANCEMENTS
 
+* Sample scripts using REST API should be updated to run with a secured Alien4Cloud ([GH-136](https://github.com/ystia/yorc-a4c-plugin/issues/136))
 * Add an example of basic job implementation for infrastructures without a default
   job scheduler ([GH-125](https://github.com/ystia/yorc-a4c-plugin/issues/125))
 
 ### BUG FIXES
+
 
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
 * Workflow ends with timeout after 4 hours and application is undeployed ([GH-131](https://github.com/ystia/yorc-a4c-plugin/issues/131))

--- a/alien4cloud-yorc-plugin/src/test/scripts/create_application
+++ b/alien4cloud-yorc-plugin/src/test/scripts/create_application
@@ -102,6 +102,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Create the applications
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/applications \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/create_location
+++ b/alien4cloud-yorc-plugin/src/test/scripts/create_location
@@ -76,6 +76,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get Orchestratror ID
 res=`curl --request GET \
+           --insecure \
           --url $a4cURL/rest/latest/orchestrators?query=Yorc \
           --header 'Accept: application/json' \
           --silent \
@@ -90,6 +91,7 @@ fi
 
 # Create the location
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations  \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/create_on_demand_google_compute
+++ b/alien4cloud-yorc-plugin/src/test/scripts/create_on_demand_google_compute
@@ -136,6 +136,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get Orchestratror ID
 res=`curl --request GET \
+          --insecure \
           --url $a4cURL/rest/latest/orchestrators?query=Yorc \
           --header 'Accept: application/json' \
           --silent \
@@ -150,6 +151,7 @@ fi
 
 # Get the location ID
 res=`curl --request GET \
+          --insecure \
           --url $a4cURL/rest/latest/orchestrators/$yorcID/locations?query=$locationName \
           --header 'Accept: application/json' \
           --silent \
@@ -165,6 +167,7 @@ fi
 
 # Create a Google Compute on-demand resource
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources  \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -188,6 +191,7 @@ fi
 
 # Update properties
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources/$resourceID/template/properties \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -202,6 +206,7 @@ then
 fi
 
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources/$resourceID/template/properties \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -216,6 +221,7 @@ then
 fi
 
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources/$resourceID/template/properties \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -231,6 +237,7 @@ fi
 
 # Add a key/value pair ssh-keys / user:ssh public key in the instance metadata
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources/$resourceID/template/properties \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -246,6 +253,7 @@ fi
 
 # Update username in credentials
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/locations/$locationID/resources/$resourceID/template/capabilities/endpoint/properties \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/create_orchestrator
+++ b/alien4cloud-yorc-plugin/src/test/scripts/create_orchestrator
@@ -78,6 +78,7 @@ fi
 
 # Create the orchestrator
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/deploy_application
+++ b/alien4cloud-yorc-plugin/src/test/scripts/deploy_application
@@ -88,6 +88,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get the Application environment ID
 res=`curl --request POST \
+          --insecure \
           --url $a4cURL/rest/latest/applications/environments \
           --header 'Content-Type: application/json' \
           --cookie cookies.a4c \
@@ -103,6 +104,7 @@ fi
 
 # Deploy the application
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/applications/deployment \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -133,6 +135,7 @@ do
     printf "."
     # Get the deployment status
     response=`curl --request POST \
+                   --insecure \
                    --url $a4cURL/rest/latest/applications/statuses \
                    --header 'Content-Type: application/json' \
                    --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/enable_orchestrator
+++ b/alien4cloud-yorc-plugin/src/test/scripts/enable_orchestrator
@@ -60,6 +60,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get Orchestratror ID
 res=`curl --request GET \
+          --insecure \
           --url $a4cURL/rest/latest/orchestrators?query=Yorc \
           --header 'Accept: application/json' \
           --silent \
@@ -74,6 +75,7 @@ fi
 
 # Enable the orchestrator
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/orchestrators/$yorcID/instance  \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/execute_workflow
+++ b/alien4cloud-yorc-plugin/src/test/scripts/execute_workflow
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#
+# execute_workflow - Execute an application workflow
+# Prerequisites : the application has been deployed
+#
+
+a4cURL="http://localhost:8088"
+userName="admin"
+password="admin"
+applicationName=""
+usage() {
+    echo ""
+    echo "Usage:"
+    echo "execute_workflow --application <Application Name>"
+    echo "                 --workflow <Workflow name>"
+    echo "                 [--a4c-url <Alien4Cloud URL>]"
+    echo "                 [--user <Alien4Cloud administrator user name>]"
+    echo "                 [--password <Alien4Cloud administrator password>]"
+    echo "   - default A4C URL  : $a4cURL"
+    echo "   - default user     : $userName"
+    echo "   - default password : $password"
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -n|--application)
+    applicationName="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -w|--workflow)
+    workflowName="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -a|--a4c-url)
+    a4cURL="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -u|--user)
+    userName="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -p|--password)
+    password="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -h|--help)
+    usage
+    exit 0
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ -z "$applicationName" ]
+then
+    echo "Error: missing mandatory parameter application name"
+    usage
+    exit 1
+fi
+
+if [ -z "$workflowName" ]
+then
+    echo "Error: missing mandatory parameter workflow name"
+    usage
+    exit 1
+fi
+
+# Load utilities
+declare -r DIR=$(cd "$(dirname "$0")" && pwd)
+source $DIR/utils.bash
+
+# First, login and store the cookies
+a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
+
+# Get the Application environment ID
+res=`curl --request POST \
+          --insecure \
+          --url $a4cURL/rest/latest/applications/environments \
+          --header 'Content-Type: application/json' \
+          --cookie cookies.a4c \
+          --silent \
+          --data "[\"$applicationName\"]"`
+envID=`getJsonval id $res`
+
+if [ -z "$envID" ]
+then
+    echo "Exiting on error getting the environment ID for Application $applicationName"
+    exit 1
+fi
+
+# Execute the workflow
+echo "Executing workflow $workflowName on $applicationName..."
+response=`curl --request POST \
+               --insecure \
+               --url $a4cURL/rest/latest/applications//$applicationName/environments/$envID/workflows/$workflowName \
+               --header 'Content-Type: application/json' \
+               --silent \
+               --cookie cookies.a4c`
+res=$?
+if [ $res -ne 0 ]
+then
+    echo "Exiting on error executing workflow $workflowName on $applicationName : $response"
+    exit 1
+fi
+
+echo "Workflow $workflowName executed on $applicationName"
+
+exit 0

--- a/alien4cloud-yorc-plugin/src/test/scripts/import_archive
+++ b/alien4cloud-yorc-plugin/src/test/scripts/import_archive
@@ -92,6 +92,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Import Git repository
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/csarsgit \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \
@@ -116,6 +117,7 @@ echo "Archive created, proceeding to the import..."
 
 # Proceed to the import
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/csarsgit/$csarID \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/select_application_location
+++ b/alien4cloud-yorc-plugin/src/test/scripts/select_application_location
@@ -82,6 +82,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get Orchestratror ID
 res=`curl --request GET \
+          --insecure \
           --url $a4cURL/rest/latest/orchestrators?query=Yorc \
           --header 'Accept: application/json' \
           --silent \
@@ -96,6 +97,7 @@ fi
 
 # Get the location ID
 res=`curl --request GET \
+          --insecure \
           --url $a4cURL/rest/latest/orchestrators/$yorcID/locations?query=Yorc \
           --header 'Accept: application/json' \
           --silent \
@@ -110,6 +112,7 @@ fi
 
 # Get the Application environment ID
 res=`curl --request POST \
+          --insecure \
           --url $a4cURL/rest/latest/applications/environments \
           --header 'Content-Type: application/json' \
           --cookie cookies.a4c \
@@ -125,6 +128,7 @@ fi
 
 # Select the application deployment location
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/applications/$applicationName/environments/$envID/deployment-topology/location-policies \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/set_application_inputs
+++ b/alien4cloud-yorc-plugin/src/test/scripts/set_application_inputs
@@ -88,6 +88,7 @@ a4c_login "$a4cURL" "$userName" "$password" "cookies.a4c"
 
 # Get the Application environment ID
 res=`curl --request POST \
+          --insecure \
           --url $a4cURL/rest/latest/applications/environments \
           --header 'Content-Type: application/json' \
           --cookie cookies.a4c \
@@ -119,6 +120,7 @@ postData="{\"inputProperties\": {$inputData}}"
 
 # Set input parameters
 response=`curl --request PUT \
+               --insecure \
                --url $a4cURL/rest/latest/applications/$applicationName/environments/$envID/deployment-topology \
                --header 'Content-Type: application/json' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/upload_yorc_plugin
+++ b/alien4cloud-yorc-plugin/src/test/scripts/upload_yorc_plugin
@@ -84,6 +84,7 @@ fi
 # Download Yorc plugin
 echo "Downloading the plugin..."
 response=`curl --request GET \
+               --insecure \
                --url $yorcPluginURL \
                --location \
                --output yorcPlugin.zip`
@@ -97,6 +98,7 @@ fi
 
 # Upload plugin in Alien4Cloud
 response=`curl --request POST \
+               --insecure \
                --url $a4cURL/rest/latest/plugins \
                --header 'Content-Type: multipart/form-data' \
                --cookie cookies.a4c \

--- a/alien4cloud-yorc-plugin/src/test/scripts/utils.bash
+++ b/alien4cloud-yorc-plugin/src/test/scripts/utils.bash
@@ -20,6 +20,7 @@ a4c_login() {
    fi
 
     curl --data "username=$2&password=$3&submit=Login"  \
+         --insecure \
          --url  $1/login \
          --dump-header headers \
 	     --silent \


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Scripts were not working against an Alien4Cloud configured to use https => added the option `--insecure` to curl commands.

Added a script to execute a workflow on an application.


### How to verify it

Install an Alien4Cloud 2.2/Yorc 4.0.0 setup.
 
Clone this repository, checkout this branch.
Then do :

```bash
$ cd yorc-a4c-plugin/alien4cloud-yorc-plugin/src/test/scripts/
$ chmod u+x *
```

Import types and topology template from a tosca sample not yet pushed to branch develop:

```bash
$ ./import_archive \
  --a4c-url https://a4chostname:8088 \
  --user myadminuser\
  --password myadminpassword \
  --repository https://github.com/ystia/yorc-a4c-plugin.git \
  --path tosca-samples/org/ystia/yorc/samples/job/noscheduler \
  --branch bugfix/GH-134-alien22
```

Create an application using this template:

```bash
$ ./create_application \
  --a4c-url https://a4chostname:8088 \
  --user myadminuser\
  --password myadminpassword \
  --name JobsExample \
  --template ChainedJobs --version 0.1.0-SNAPSHOT
Application JobsExample created
```

Then, you have to select where you want to deploy the application, here this script will select the HostsPool location that was created after the Ystia installation:

```bash
$ ./select_application_location  \
  --a4c-url https://a4chostname:8088 \
  --user myadminuser\
  --password myadminpassword \
  --application JobsExample \
  --location HostsPool
Selected location HostsPool for application JobsExample
```

The application can now be deployed.

This command will deploy the application, which will consist first in creating a compute instance, then in deploying the application on this compute instance created on demand (it should take several minutes):

```bash
$ ./deploy_application \
  --a4c-url https://a4chostname:8088 \
  --user myadminuser\
  --password myadminpassword \
  --application JobsExample

Application JobsExample deployment in progress..............
Application JobsExample deployed
```

The application is deployed now.
Execute run workflow:

```bash
$ ./execute_workflow \
  --a4c-url https://a4chostname:8088 \
  --user myadminuser\
  --password myadminpassword \
  --application JobsExample \
  --workflow run
Executing workflow run on JobsExample...
```

While the command is running, login on the UI, select the application, select its workflow run and check this workflow is running.


### Description for the changelog

Sample scripts using REST API should be updated to run with a secured Alien4Cloud ([GH-136](https://github.com/ystia/yorc-a4c-plugin/issues/136))

## Applicable Issues

Fixes #136 
