### PR TITLE
Backport/gh 140 workflow consumes cpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Running a custom workflow consumes 100% of one CPU thread ([GH-140](https://github.com/ystia/yorc/issues/140))
+
 ## 3.2.1 (July 05, 2019)
 
 ### BUG FIXES

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
@@ -32,7 +32,7 @@ public class WorkflowTask extends AlienTask {
     IPaaSCallback<?> callback;
     String workflowName;
     Map<String, Object> inputs;
-    private final int WAIT_EVENT_TIMEOUT = 1000 * 60; // 60 seconds
+    private final int WAIT_EVENT_TIMEOUT = 1000 * 300; // 5 minutes
     
     public WorkflowTask(PaaSDeploymentContext ctx, YorcPaaSProvider prov, String workflowName, Map<String, Object> inputs, IPaaSCallback<?> callback) {
         super(prov);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
@@ -32,6 +32,7 @@ public class WorkflowTask extends AlienTask {
     IPaaSCallback<?> callback;
     String workflowName;
     Map<String, Object> inputs;
+    private final int WAIT_EVENT_TIMEOUT = 1000 * 60; // 60 seconds
     
     public WorkflowTask(PaaSDeploymentContext ctx, YorcPaaSProvider prov, String workflowName, Map<String, Object> inputs, IPaaSCallback<?> callback) {
         super(prov);
@@ -68,30 +69,53 @@ public class WorkflowTask extends AlienTask {
         boolean done = false;
         while (!done && error == null) {
             synchronized (jrdi) {
-                // Check workflow related event
+                // Wait for Events from Yorc
+                log.debug(paasId + ": Waiting for Worflow events.");
+                try {
+                    jrdi.wait(WAIT_EVENT_TIMEOUT);
+                } catch (InterruptedException e) {
+                    log.error(paasId + ": Interrupted while waiting for Workflow event");
+                    break;
+                }
+
+                String status;
+                // Woke up on wait timeout or event received
+                // Checking if this is a workflow event
                 Event evt = jrdi.getLastEvent();
                 if (evt != null && evt.getType().equals(EventListenerTask.EVT_WORKFLOW) && taskId.equals(evt.getAlienExecutionId())) {
                     jrdi.setLastEvent(null);
-                    switch (evt.getStatus()) {
-                        case "failed":
-                            log.debug("Workflow failed");
-                            error = new Exception("Workflow failed");
-                            break;
-                        case "canceled":
-                            log.debug("Workflow failed");
-                            error = new Exception("Workflow canceled");
-                            break;
-                        case "done":
-                            log.debug("Workflow OK");
-                            done = true;
-                            break;
-                        default:
-                            log.debug("Workflow Status is currently " + evt.getStatus());
-                            break;
+                    status = evt.getStatus();
+                } else {
+                    // No event received for this workflow, checking the task
+                    // status to confirm it is ongoing
+                    try {
+                        status = restClient.getStatusFromYorc(taskUrl).toLowerCase();
+                        log.debug("Task " + taskId + " returned status:" + status);
+                    } catch (Exception e) {
+                        log.debug("Attemptin to get task " + taskId + " status throws" + e.getMessage());
+                        status = "failed";
                     }
+                }
+                switch (status) {
+                    case "failed":
+                        log.debug("Workflow failed");
+                        error = new Exception("Workflow failed");
+                        break;
+                    case "canceled":
+                        log.debug("Workflow canceled");
+                        error = new Exception("Workflow canceled");
+                        break;
+                    case "done":
+                        log.debug("Workflow OK");
+                        done = true;
+                        break;
+                    default:
+                        log.debug("Workflow Status is currently " + status);
+                        break;
                 }
             }
         }
+
         synchronized (jrdi) {
             // Task is ended: Must remove the taskId and notify a possible undeploy waiting for it.
             jrdi.setDeployTaskId(null);

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
@@ -92,7 +92,7 @@ public class WorkflowTask extends AlienTask {
                         status = restClient.getStatusFromYorc(taskUrl).toLowerCase();
                         log.debug("Task " + taskId + " returned status:" + status);
                     } catch (Exception e) {
-                        log.debug("Attempting to get task " + taskId + " status throws " + e.getMessage());
+                        log.error("Failed to get task " + taskId + " status", e);
                         status = "failed";
                     }
                 }

--- a/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
+++ b/alien4cloud-yorc-plugin/src/main/java/org/ystia/yorc/alien4cloud/plugin/WorkflowTask.java
@@ -92,7 +92,7 @@ public class WorkflowTask extends AlienTask {
                         status = restClient.getStatusFromYorc(taskUrl).toLowerCase();
                         log.debug("Task " + taskId + " returned status:" + status);
                     } catch (Exception e) {
-                        log.debug("Attemptin to get task " + taskId + " status throws" + e.getMessage());
+                        log.debug("Attempting to get task " + taskId + " status throws " + e.getMessage());
                         status = "failed";
                     }
                 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue where running a custom workfkow was resulting in having the Alien4Cloud process consume entirely one CPU.

### What I did

Added a wait() to  sleep and be awaken either on event received or on timeout.
If no event was received yet for this workflow, getting the task status if ever an event was missed.

### How to verify it

Create a topology using the python example provided in tosca-samples.
Add a custom workflow chaining the operations say_hello and say_goodbye.

Deploy the application.
Once done, run the custom workflow you defined, and once this workflow is running, check the CPU consumption to verify Alien4Cloud won't consume on CPU during the whole run of this workflow.

### Description for the changelog

Running a custom workflow consumes 100% of one CPU thread ([GH-140](https://github.com/ystia/yorc/issues/140))

## Applicable Issues

Fixes #140 