### PR TITLE
Feature/gh 139 openstack volume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - secure: "WS0CXs5AbxhJR+NCsvlvbkqL79/2flWZ2SJ8CeoPxlVdkviOGSrLg5V+edEciAJFe/8SvFBfTG+ESaeze2TGwVJrv6IpBvDiJxkC63AigjbbCHAPWsxCGHIq3DfG9K+ZDU2L1wNSOa6rWEfPQdIrnL/nELTWGNrqiqikCNqpBergwdmlghT54h4Qmyi/IWvmVagb2SoUxLMUUbzga8Kkc/ajfmJx5dKV4WyOADeojP0Dgv+ZQyEIy2SQOAw7hf4wO8DHWiTnWqzg0OgUHaExFZx/cjgtRyKyBf4zZ4w3QcfXbAPwX7Cczyql+zfGmm4Ge+Cx5gayhVtXtpfB45rZKDv3gsXQ130a3fLgRDCcBixqbz5tOzwEcQezL+Xz13ue2u0c7BOObglJ5HZPlsNKwDSuJEaNEYI0Dd9yoB+3Qf5YeJSKNRfRRGuMQn0ZGXUiMTL3X9gGIBA2p86CWuHicQgk0wtLu0pvXnrGH4C+JDmHCxEGYV+nHvTrG7Xy4e7cqoCIuhLAP6ofv25i7MARzl0olMHWJtOfVoh+xU3jfr0+T5b8DpqSlfcKjE5TV5mWvsSg9WizEDaKrIS6bzucDx5tPI/8XbLzTbzC7AiLHKQql2wKhXbt6LjrfB5/UMrHmRE83k7FlEEfGovufAIh7WsfchMd7oQpIHoal8w0xUs="
 
 install:
-  - pip install --user --upgrade sphinx==1.7.9 semantic-version requests urllib3[secure]
+  - pip install --user --upgrade sphinx==1.7.9 semantic-version requests urllib3[secure] pyOpenSSL==16.2.0
   - curl -fL https://getcli.jfrog.io | sh
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### ENHANCEMENTS
 
+* Should support the creation of OpenStack Compute instances using bootable volume ([GH-139](https://github.com/ystia/yorc-a4c-plugin/issues/139))
 * Sample scripts using REST API should be updated to run with a secured Alien4Cloud ([GH-136](https://github.com/ystia/yorc-a4c-plugin/issues/136))
 * Add an example of basic job implementation for infrastructures without a default
   job scheduler ([GH-125](https://github.com/ystia/yorc-a4c-plugin/issues/125))

--- a/alien4cloud-yorc-plugin/pom.xml
+++ b/alien4cloud-yorc-plugin/pom.xml
@@ -37,7 +37,7 @@
         <yorc.google.types.version>1.0.0</yorc.google.types.version>
         <yorc.hp.types.version>1.0.0</yorc.hp.types.version>
         <yorc.k8s.types.version>2.0.0</yorc.k8s.types.version>
-        <yorc.os.types.version>1.1.0</yorc.os.types.version>
+        <yorc.os.types.version>1.2.0</yorc.os.types.version>
         <yorc.slurm.types.version>1.2.0</yorc.slurm.types.version>
       </properties>
 

--- a/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
@@ -16,7 +16,7 @@ data_types:
       uuid:
         type: string
         required: false
-        description: UUID of the image, volume, or snapshot. Required if source is set to 'blank'
+        description: UUID of the image, volume, or snapshot. Required unless source is set to 'blank'
       source:
         type: string
         required: true

--- a/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
@@ -9,6 +9,39 @@ imports:
   - alien-base-types:${alien4cloud.version}
   - yorc-types:${yorc.types.version}
 
+data_types:
+  yorc.datatypes.openstack.BootVolume:
+    derived_from: tosca.datatypes.Root
+    properties:
+      uuid:
+        type: string
+        required: false
+        description: UUID of the image, volume, or snapshot. Required if source is set to 'blank'
+      source:
+        type: string
+        required: true
+        description: Source type of the device. Must be one of 'blank', 'image', 'volume', or 'snapshot'
+        constraints:
+          - valid_values: [ blank, image, volume, snapshot ]
+      destination:
+        type: string
+        required: false
+        description: Destination type, possible values are 'volume' or 'local'
+        constraints:
+          - valid_values: [ volume, local ]
+      size:
+        type: scalar-unit.size
+        required: false
+        description: >
+          Size of volume to create (default unit is MB). Required when source=image and destination=volume,
+          source=blank and destination=local, or source=blank and destination=volume
+        constraints:
+          - greater_or_equal: 1 GB
+      delete_on_termination:
+        type: boolean
+        required: false
+        default: true
+        description: Delete the volume upon termination of the instance
 artifact_types:
   yorc.artifacts.openstack.Deployment:
     derived_from: tosca.artifacts.Deployment
@@ -77,13 +110,18 @@ node_types:
     properties:
       image:
         type: string
-        description: The Openstack VM Image ID either this property or the 'imageName' property is required
+        description: >
+          Openstack VM Image ID, this property is required when 'imageName' is not set and not booting from a volume
         required: false
       imageName:
         type: string
         description: >
-          The Openstack VM Image Name either this property or the 'image' property is required. This property can be used only if the image
-          name is unique.
+          Openstack VM Image Name, this property is required when 'image' is not set and not booting from a volume
+        required: false
+      bootVolume:
+        type: yorc.datatypes.openstack.BootVolume
+        description: >
+          Boot Volume to create
         required: false
       flavor:
         type: string

--- a/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
+++ b/alien4cloud-yorc-plugin/src/main/resources/openstack/resources/resources.yaml
@@ -118,7 +118,7 @@ node_types:
         description: >
           Openstack VM Image Name, this property is required when 'image' is not set and not booting from a volume
         required: false
-      bootVolume:
+      boot_volume:
         type: yorc.datatypes.openstack.BootVolume
         description: >
           Boot Volume to create


### PR DESCRIPTION
# Pull Request description

## Description of the change

Allow to create an OpenStack Compute Instance using a bootable Volume.
The need to backport this changed in the new Alien4Cloud Yorc provider is tracked by issue https://github.com/alien4cloud/alien4cloud-yorc-provider/issues/5

### What I did

Added a BootVolume data type, and an optional property boot_volume of this type in yorc.nodes.openstack.Compute.

Increased the version number of yorc.os.types.version after this change in OpenStack types.

Misc.: Fixed build failures in travis, replacing the install of oracle jdk by the install of open jdk, and installing a fixed version of pyOpenSLL

### How to verify it

See corresponding section in Yorc pull request https://github.com/ystia/yorc/pull/483

### Description for the changelog

Should support the creation of OpenStack Compute instances using bootable volume ([GH-139](https://github.com/ystia/yorc-a4c-plugin/issues/139))

## Applicable Issues

Fixes #139 